### PR TITLE
Decouple the PWA API in v1.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jshint": "^2.9.6"
   },
   "scripts": {
-    "test": "jshint ./bundle/default/service-worker.js"
+    "test": "jshint ./packages/cdn/src/index.js"
   },
   "dependencies": {}
 }

--- a/packages/cdn/README.md
+++ b/packages/cdn/README.md
@@ -15,12 +15,8 @@ Copy text to clipboard
 #### Copy from a single element
 
 ```js
-// Define styles of the success message as a string
-const styles = ``;
-// Copy from a single element
-const element = document.getElementById("copy");
 // Copy text
-pwa.copyText(element, styles);
+pwa.copyText(text);
 ```
 
 #### Copy from multiple elements
@@ -30,7 +26,7 @@ pwa.copyText(element, styles);
 const elements = document.querySelectorAll(".copy");
 for (let el of elements) {
   // Copy text
-  pwa.copyText(el, styles);
+  pwa.copyText(text);
 }
 ```
 
@@ -48,7 +44,7 @@ const imgURL = img.src;
 #### Call the copyImage method on pwa
 
 ```js
-img.addEventListener("click", (event) => {
+img.addEventListener("click", event => {
   event.preventDefault();
   pwa.copyImage(imgURL);
 });
@@ -80,18 +76,12 @@ const data = {
 #### Call the share method on pwa
 
 ```js
-pwa.Share(element, data);
+pwa.Share(data);
 ```
 
 ### 4. Contacts Picker
 
 [Contacts Picker API](https://github.com/pwafire/pwafire/tree/master/bundle/contact-picker) allows a PWA to access contacts from the device's native contacts manager. **Chrome 77** or higher running on **Android M or later** required.
-
-#### Add the contact picker element(button)
-
-```js
-const element = document.getElementById("contacts-picker");
-```
 
 #### Define the "properties" and "select type" option you need
 
@@ -103,9 +93,8 @@ const options = { multiple: true };
 #### Call the contacts method on pwa, it returns selected contacts
 
 ```js
-pwa.Contacts(element, props, options);
 // You can save the return value in a variable...
-const contacts = pwa.Contacts(element, props, options);
+const contacts = pwa.Contacts(props, options);
 ```
 
 ### 5. Show PWA Connectivity status
@@ -135,16 +124,10 @@ pwa.Connectivity(online, offline);
 
 Open app in fullscreen on a click event
 
-#### Add the specific element(e.g button)
-
-```js
-const element = document.getElementById("fullscreen-button");
-```
-
 #### Call the fullscreen method
 
 ```js
-pwa.Fullscreen(element);
+pwa.Fullscreen();
 ```
 
 ### 7. Notifications
@@ -167,28 +150,18 @@ const data = {
 #### Call the notification method, pass in `data` object, for e.g
 
 ```js
-// Add an event listener to a button element...
-const notification = document.getElementById("notification");
-notification.addEventListener("click", (event) => {
-  // Call the notification method...
-  pwa.Notification(data);
-});
+// Call the notification method...
+pwa.Notification(data);
 ```
 
 ### 8. Install
 
 Add custom install button
 
-#### Add the specific element(e.g button)
-
-```js
-const element = document.getElementById("install");
-```
-
 #### Call the install method
 
 ```js
-pwa.Install(element);
+pwa.Install();
 ```
 
 #### 9. Visibility
@@ -229,7 +202,7 @@ available to **a merchant.**
 #### Call Payment method with three arguments
 
 ```js
-let paymentResponse = pwa.Payment(pay, paydata, validatePayment);
+const paymentResponse = pwa.Payment(pay, paydata, validatePayment);
 ```
 
 #### Example : compute total amount to pay

--- a/packages/cdn/src/index.js
+++ b/packages/cdn/src/index.js
@@ -1,27 +1,48 @@
-// All PWA Fire Bundle Features as ES6 Module
-// Declare the PWA Features class...
+// All PWA Fire Bundle Features as ES6 Module @copyright : mayeedwin
 class PWA {
   // Copy text...
-  copyText(element, styles) {
-    let style = ``;
-    if (styles) {
-      style = styles
-    }
-    element.addEventListener("click", async (event) => {
-      let html = element.innerHTML;
-      let text = element.innerText;
+  copyText(text) {
       try {
         await navigator.clipboard.writeText(text);
-        // Show success message...
-        element.innerHTML = `<span style="${style}">
-                Copied to clipboard!</span>`;
-        // Show previous text...
-        setTimeout(() => {
-          element.innerHTML = html;
-        }, 3000);
       } catch (err) {
         console.error("Failed to copy to clipboard", err);
       }
+  }
+  // Web Share...
+  Share(data) {
+      // Check if web share is supported
+      if (navigator.share) {
+        navigator
+          .share(data)
+          .then(() => console.log(`Shared`))
+          .catch((error) => console.log(`Error sharing`, error));
+      } else {
+        console.log(`Web share not supported!`);
+      };
+  }
+  // Contacts Picker...
+  async Contacts(props, options) {
+      try {
+        const contacts = await navigator.contacts.select(props, options);
+        // Return contacts...
+        return contacts;
+      } catch (error) {
+        // Handle any errors here...
+        alert(error);
+      }
+  }
+  // Connectivity...
+  Connectivity(online, offline) {
+    // Once the DOM is loaded, check for connectivity...
+    document.addEventListener("DOMContentLoaded", () => {
+      // Offline Event...
+      if (!navigator.onLine) {
+        offline();
+      }
+      // Online Event...
+      window.addEventListener("online", () => {
+        online();
+      });
     });
   }
   // Copy image
@@ -42,33 +63,6 @@ class PWA {
     } catch (e) {
       console.error(e, e.message);
     }
-  }
-  // Contacts Picker...
-  Contacts(element, props, options) {
-    element.addEventListener("click", async () => {
-      try {
-        const contacts = await navigator.contacts.select(props, options);
-        // Return contacts...
-        return contacts;
-      } catch (error) {
-        // Handle any errors here...
-        alert(error);
-      }
-    });
-  }
-  // Connectivity...
-  Connectivity(online, offline) {
-    // Once the DOM is loaded, check for connectivity...
-    document.addEventListener("DOMContentLoaded", () => {
-      // Offline Event...
-      if (!navigator.onLine) {
-        offline();
-      }
-      // Online Event...
-      window.addEventListener("online", () => {
-        online();
-      });
-    });
   }
   // Badge...
   Badge(unreadCount) {
@@ -91,10 +85,7 @@ class PWA {
     };
   }
   // Payment...
-  Payment(element, paydata, validatePayment) {
-    // Initiate Payment UI on click...
-    element.addEventListener("click", (event) => {
-      event.preventDefault();
+  Payment(paydata, validatePayment) {
       const paymentRequest = new PaymentRequest(
         paydata.paymentMethods,
         paydata.paymentDetails,
@@ -111,17 +102,12 @@ class PWA {
           // API error or user cancelled the payment
           console.log("Error:", err);
         });
-    });
   }
   // Fullscreen...
-  Fullscreen(element) {
-    element.addEventListener("click", (event) => {
-      event.preventDefault();
-
+  Fullscreen() {
       if (document.fullscreenEnabled) {
         document.documentElement.requestFullscreen();
       }
-    });
   }
   // Notification...
   Notification(data) {
@@ -143,13 +129,11 @@ class PWA {
     }
   }
   // Install...
-  Install(element) {
+  Install() {
     window.addEventListener("beforeinstallprompt", (event) => {
       // Stash the event so it can be triggered later...
       window.deferredPrompt = event;
     });
-
-    element.addEventListener("click", () => {
       console.log(`"👍", Install Button Clicked`);
       const promptEvent = window.deferredPrompt;
       if (!promptEvent) {
@@ -164,8 +148,6 @@ class PWA {
         // Reset the deferred prompt variable, since rompt() can only be called once...
         window.deferredPrompt = null;
       });
-    });
-
     window.addEventListener("appinstalled", (event) => {
       console.log(`"👍", App Installed`);
     });

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -27,12 +27,8 @@ Copy text to clipboard
 #### Copy from a single element
 
 ```js
-// Define styles of the success message as a string
-const styles = ``;
-// Copy from a single element
-const element = document.getElementById("copy");
 // Copy text
-pwa.copyText(element, styles);
+pwa.copyText(text);
 ```
 
 #### Copy from multiple elements
@@ -42,7 +38,7 @@ pwa.copyText(element, styles);
 const elements = document.querySelectorAll(".copy");
 for (let el of elements) {
   // Copy text
-  pwa.copyText(el, styles);
+  pwa.copyText(text);
 }
 ```
 
@@ -92,18 +88,12 @@ const data = {
 #### Call the share method on pwa
 
 ```js
-pwa.Share(element, data);
+pwa.Share(data);
 ```
 
 ### 4. Contacts Picker
 
 [Contacts Picker API](https://github.com/pwafire/pwafire/tree/master/bundle/contact-picker) allows a PWA to access contacts from the device's native contacts manager. **Chrome 77** or higher running on **Android M or later** required.
-
-#### Add the contact picker element(button)
-
-```js
-const element = document.getElementById("contacts-picker");
-```
 
 #### Define the "properties" and "select type" option you need
 
@@ -115,9 +105,8 @@ const options = { multiple: true };
 #### Call the contacts method on pwa, it returns selected contacts
 
 ```js
-pwa.Contacts(element, props, options);
 // You can save the return value in a variable...
-const contacts = pwa.Contacts(element, props, options);
+const contacts = pwa.Contacts(props, options);
 ```
 
 ### 5. Show PWA Connectivity status
@@ -147,16 +136,10 @@ pwa.Connectivity(online, offline);
 
 Open app in fullscreen on a click event
 
-#### Add the specific element(e.g button)
-
-```js
-const element = document.getElementById("fullscreen-button");
-```
-
 #### Call the fullscreen method
 
 ```js
-pwa.Fullscreen(element);
+pwa.Fullscreen();
 ```
 
 ### 7. Notifications
@@ -179,28 +162,18 @@ const data = {
 #### Call the notification method, pass in `data` object, for e.g
 
 ```js
-// Add an event listener to a button element...
-const notification = document.getElementById("notification");
-notification.addEventListener("click", (event) => {
   // Call the notification method...
   pwa.Notification(data);
-});
 ```
 
 ### 8. Install
 
 Add custom install button
 
-#### Add the specific element(e.g button)
-
-```js
-const element = document.getElementById("install");
-```
-
 #### Call the install method
 
 ```js
-pwa.Install(element);
+pwa.Install();
 ```
 
 #### 9. Visibility
@@ -241,7 +214,7 @@ available to **a merchant.**
 #### Call Payment method with three arguments
 
 ```js
-let paymentResponse = pwa.Payment(pay, paydata, validatePayment);
+const paymentResponse = pwa.Payment(pay, paydata, validatePayment);
 ```
 
 #### Example : compute total amount to pay

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Progressive Web Apps API of APIs",
   "main": "src/index.js",
   "scripts": {

--- a/packages/npm/src/index.js
+++ b/packages/npm/src/index.js
@@ -1,47 +1,27 @@
-// All PWA Fire Bundle Features as ES6 Module
-// Declare the PWA Features class...
+// All PWA Fire Bundle Features as ES6 Module @copyright : mayeedwin
 class PWA {
   // Copy text...
-  copyText(element, styles) {
-    let style = ``;
-    if (styles) {
-      style = styles
-    }
-    element.addEventListener("click", async (event) => {
-      event.preventDefault();
-      let html = element.innerHTML;
-      let text = element.innerText;
+  copyText(text) {
       try {
         await navigator.clipboard.writeText(text);
-        // Show success message...
-        element.innerHTML = `<span style="${style}">
-                Copied to clipboard!</span>`;
-        // Show previous text...
-        setTimeout(() => {
-          element.innerHTML = html;
-        }, 3000);
       } catch (err) {
         console.error("Failed to copy to clipboard", err);
       }
-    });
   }
   // Web Share...
-  Share(element, data) {
-    element.addEventListener(`click`, () => {
+  Share(data) {
       // Check if web share is supported
       if (navigator.share) {
         navigator
           .share(data)
-          .then(() => console.log(`Successful share`))
+          .then(() => console.log(`Shared`))
           .catch((error) => console.log(`Error sharing`, error));
       } else {
-        console.log(`Web share not supported on desktop...`);
-      }
-    });
+        console.log(`Web share not supported!`);
+      };
   }
   // Contacts Picker...
-  Contacts(element, props, options) {
-    element.addEventListener("click", async () => {
+  async Contacts(props, options) {
       try {
         const contacts = await navigator.contacts.select(props, options);
         // Return contacts...
@@ -50,7 +30,6 @@ class PWA {
         // Handle any errors here...
         alert(error);
       }
-    });
   }
   // Connectivity...
   Connectivity(online, offline) {
@@ -106,10 +85,7 @@ class PWA {
     };
   }
   // Payment...
-  Payment(element, paydata, validatePayment) {
-    // Initiate Payment UI on click...
-    element.addEventListener("click", (event) => {
-      event.preventDefault();
+  Payment(paydata, validatePayment) {
       const paymentRequest = new PaymentRequest(
         paydata.paymentMethods,
         paydata.paymentDetails,
@@ -126,17 +102,12 @@ class PWA {
           // API error or user cancelled the payment
           console.log("Error:", err);
         });
-    });
   }
   // Fullscreen...
-  Fullscreen(element) {
-    element.addEventListener("click", (event) => {
-      event.preventDefault();
-
+  Fullscreen() {
       if (document.fullscreenEnabled) {
         document.documentElement.requestFullscreen();
       }
-    });
   }
   // Notification...
   Notification(data) {
@@ -158,13 +129,11 @@ class PWA {
     }
   }
   // Install...
-  Install(element) {
+  Install() {
     window.addEventListener("beforeinstallprompt", (event) => {
       // Stash the event so it can be triggered later...
       window.deferredPrompt = event;
     });
-
-    element.addEventListener("click", () => {
       console.log(`"👍", Install Button Clicked`);
       const promptEvent = window.deferredPrompt;
       if (!promptEvent) {
@@ -179,8 +148,6 @@ class PWA {
         // Reset the deferred prompt variable, since rompt() can only be called once...
         window.deferredPrompt = null;
       });
-    });
-
     window.addEventListener("appinstalled", (event) => {
       console.log(`"👍", App Installed`);
     });


### PR DESCRIPTION
## Breaking Changes v1.8.7

Allow Developers to have an ability to do much with the API itself as shown below;

### Copy Text
Have a look at the following changes...

#### Previously 
```js
// Define styles of the success message as a string
const styles = ``;
// Copy from a single element
const element = document.getElementById("copy");
// Copy text
pwa.copyText(element, styles);
```

#### New syntax
So, you can have this wherever you need, all you need to do is pass in the text to copy.
```js
 pwa.Copy(text)
```

#### Say, I had a 'copy' button element, then;

```js
const text = `Some text`;
element.addEventListener('click', event => {
   pwa.Copy(text)
})
```