### PR TITLE
Feature : Access Local Fonts

### DIFF
--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -114,7 +114,7 @@ import { check } from "pwafire";
 const isSupported = await check.Share();
 ```
 
-### 1. Copy Text
+### Copy Text
 
 Copy text to clipboard.
 
@@ -125,7 +125,7 @@ Copy text to clipboard.
 pwa.copyText(text);
 ```
 
-### 2. Read Text
+### Read Text
 
 Read text from clipboard.
 
@@ -136,7 +136,7 @@ Read text from clipboard.
 const res = await pwa.readText();
 ```
 
-### 3. Copy image (Only PNG are supported for security purposes) to clipboard
+### Copy image (Only PNG are supported for security purposes) to clipboard
 
 Copy png images to clipboard
 
@@ -146,7 +146,7 @@ Copy png images to clipboard
 const res = await pwa.copyImage(imgURL);
 ```
 
-### 4. Read files e.g images from clipboard
+### Read files e.g images from clipboard
 
 Read png images from clipboard
 
@@ -156,7 +156,7 @@ Read png images from clipboard
 const res = await pwa.readFiles();
 ```
 
-### 5. Web Share
+### Web Share
 
 Share links, text, and files to other apps installed on the device.
 
@@ -179,7 +179,7 @@ const data = {
 const res = await pwa.Share(data);
 ```
 
-### 6. Contacts Picker
+### Contacts Picker
 
 [Contacts Picker API](https://github.com/pwafire/pwafire/tree/master/bundle/contact-picker) allows a PWA to access contacts from the mobile device's native contacts manager.
 
@@ -203,7 +203,7 @@ pwa.Contacts(props, options).then((res) => {
 });
 ```
 
-### 7. Show PWA Connectivity status
+### Show PWA Connectivity status
 
 Pass in two call back funtions, aka **online** and **offline** handlers.
 
@@ -226,7 +226,7 @@ const offline = () => {
 pwa.Connectivity(online, offline);
 ```
 
-### 8. Fullscreen
+### Fullscreen
 
 Open app in fullscreen on a click event
 
@@ -236,7 +236,7 @@ Open app in fullscreen on a click event
 pwa.Fullscreen();
 ```
 
-### 9. Notifications
+### Notifications
 
 Show notifications. Pass a **data** object
 
@@ -260,7 +260,7 @@ const data = {
 pwa.Notification(data);
 ```
 
-### 10. Install, add custom installation logic
+### Install, add custom installation logic
 
 Provide an installation step **type** (`before, installed or install`), and a **callback** function as a parameters to the **Install** method on pwa . This is a new feature in v4.0.7+
 
@@ -335,7 +335,7 @@ Provide an installation step **type** (`before, installed or install`), and a **
 - For other apps, make sure the first two steps run on **page load**, and the third step is called
   on button click.
 
-### 11. Badging
+### Badging
 
 #### Add badging for app icons
 
@@ -358,7 +358,7 @@ pwa.setBadge(unreadCount);
 pwa.clearBadge();
 ```
 
-### 12. Screen Wake Lock API
+### Screen Wake Lock API
 
 The Screen Wake Lock API provides a way to prevent devices from dimming or locking the screen when an application needs to keep running.
 
@@ -368,7 +368,7 @@ The Screen Wake Lock API provides a way to prevent devices from dimming or locki
 pwa.WakeLock();
 ```
 
-### 13. Visibility
+### Visibility
 
 Check if user is viewing a page. Pause/play video or games e.t.c
 
@@ -396,7 +396,7 @@ const notAvailable = () => {
 pwa.Visibility(isVisible, notAvailable);
 ```
 
-### 14. The File System Access API
+### The File System Access API
 
 _The File System Access API_ allows web apps to read or save changes directly to files and folders on the user's device.
 
@@ -420,7 +420,7 @@ const res = await pwa.pickTextFile();
 const contents = res.ok ? res.contents : null;
 ```
 
-### 15. Content Indexing
+### Content Indexing
 
 This API allows you to index your offline-capable pages.
 
@@ -479,7 +479,7 @@ const res = index.removeItem({
 const items = await index.getAll();
 ```
 
-### 16. Barcode Detection
+### Barcode Detection
 
 Unlock interesting use cases like online payments or web navigation, or use barcodes for establishing social connections on messenger applications.
 
@@ -507,7 +507,54 @@ if (res.ok) {
 }
 ```
 
-### 17. Web Payments
+### Font Access
+
+Allows you to access the user's locally installed fonts and obtain low-level details about them.
+
+#### Call the fontAccess method on pwa
+
+```js
+const res = await pwa.fontAccess();
+if (res.ok) {
+  // Do something.
+  const fonts = res.fonts;
+} else {
+  // Do something.
+}
+```
+
+#### Accessing SFNT data
+
+```js
+const res = await pwa.fontAccess({
+  sfnt: true,
+});
+if (res.ok) {
+  // Do something.
+  const fonts = res.fonts;
+  const sfntFormats = res.sfntFormats;
+} else {
+  // Do something.
+}
+```
+
+### Get subset of fonts
+
+You can also filter them based on the `PostScript` names by adding a postscriptNames parameter, an array of strings.
+
+```js
+const res = await pwa.fontAccess({
+  postscriptNames: ["Verdana", "Verdana-Bold", "Verdana-Italic"],
+});
+if (res.ok) {
+  // Do something.
+  const fonts = res.fonts;
+} else {
+  // Do something.
+}
+```
+
+### Web Payments
 
 Allows users select their preferred way of **paying for things**, and make that information
 available to **a merchant.**

--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -530,9 +530,8 @@ const res = await pwa.accessFonts({
   sfnt: true,
 });
 if (res.ok) {
-  // Do something.
-  const fonts = res.fonts;
-  const sfntFormats = res.sfntFormats;
+  // Do something with the sfnt data.
+  const sfntFormats = res.sfnt;
 } else {
   // Do something.
 }

--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -537,7 +537,7 @@ if (res.ok) {
 }
 ```
 
-### Get subset of fonts
+#### Get subset of fonts
 
 You can also filter them based on the `PostScript` names by adding a postscriptNames parameter, an array of strings.
 

--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -511,10 +511,10 @@ if (res.ok) {
 
 Allows you to access the user's locally installed fonts and obtain low-level details about them.
 
-#### Call the fontAccess method on pwa
+#### Call the accessFonts method on pwa
 
 ```js
-const res = await pwa.fontAccess();
+const res = await pwa.accessFonts();
 if (res.ok) {
   // Do something.
   const fonts = res.fonts;
@@ -526,7 +526,7 @@ if (res.ok) {
 #### Accessing SFNT data
 
 ```js
-const res = await pwa.fontAccess({
+const res = await pwa.accessFonts({
   sfnt: true,
 });
 if (res.ok) {
@@ -543,7 +543,7 @@ if (res.ok) {
 You can also filter them based on the `PostScript` names by adding a postscriptNames parameter, an array of strings.
 
 ```js
-const res = await pwa.fontAccess({
+const res = await pwa.accessFonts({
   postscriptNames: ["Verdana", "Verdana-Bold", "Verdana-Italic"],
 });
 if (res.ok) {

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "5.0.",
+  "version": "5.0.2-alpha",
   "description": "Progressive Web App API of APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "5.0.2-alpha",
+  "version": "5.0.2",
   "description": "Progressive Web App API of APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/pwafire/src/check/index.ts
+++ b/packages/pwafire/src/check/index.ts
@@ -146,7 +146,7 @@ class Check {
   }
 
   // Check for font access support.
-  async fontAccess() {
+  async accessFonts() {
     try {
       // Check for font access support.
       return "queryLocalFonts" in window ? true : false;
@@ -293,8 +293,8 @@ class Check {
 
         {
           name: "Font Access",
-          message: (await this.fontAccess()) ? "Supported" : "Not supported",
-          ok: await this.fontAccess(),
+          message: (await this.accessFonts()) ? "Supported" : "Not supported",
+          ok: await this.accessFonts(),
         },
         {
           name: "Service Worker",

--- a/packages/pwafire/src/pwa/index.ts
+++ b/packages/pwafire/src/pwa/index.ts
@@ -668,7 +668,7 @@ class PWA {
             ok: true,
             message: "Fonts access",
             fonts,
-            outlineFormats: config.sfnt ? await getSFNT(fonts) : [],
+            sfnt: config.sfnt ? await getSFNT(fonts) : [],
           };
         } else {
           const fonts: FontData[] = await window.queryLocalFonts();
@@ -676,7 +676,7 @@ class PWA {
             ok: true,
             message: "Fonts access",
             fonts,
-            outlineFormats: config && config.sfnt ? await getSFNT(fonts) : [],
+            sfnt: config && config.sfnt ? await getSFNT(fonts) : [],
           };
         }
       } else {

--- a/packages/pwafire/src/pwa/index.ts
+++ b/packages/pwafire/src/pwa/index.ts
@@ -651,7 +651,7 @@ class PWA {
                 break;
             }
             // Add outline format to array.
-            outlineFormat !== "" ? outlineFormats.push(outlineFormat) : null;
+            if (outlineFormat !== "") outlineFormats.push(outlineFormat);
           }
           // Return outline formats.
           return outlineFormats;

--- a/packages/pwafire/src/pwa/index.ts
+++ b/packages/pwafire/src/pwa/index.ts
@@ -627,18 +627,18 @@ class PWA {
    * Access local device fonts.
    * @method localFontsAccess
    */
-  async localFontsAccess(config?: { postscriptNames?: string[]; accessSFNT?: boolean }) {
+  async accessFonts(config?: { postscriptNames?: string[]; sfnt?: boolean }) {
     try {
-      //  SFNT is a font file format that is used by OpenType, TrueType, and PostScript fonts.
-      const getSFNT = async (availableFonts: any[]) => {
+      // SFNT is a font file format that is used by OpenType, TrueType, and PostScript fonts.
+      const getSFNT = async (availableFonts: FontData[]) => {
         try {
           // Outline formats.
           const outlineFormats = [];
           for (const fontData of availableFonts) {
             // Get a blob containing valid and complete SFNT-wrapped font data.
-            const sfnt = await fontData.blob();
+            const sfntBlob = await fontData.blob();
             // Slice out only the bytes we need: the first 4 bytes are the SFNT.
-            const sfntVersion = await sfnt.slice(0, 4).text();
+            const sfntVersion = await sfntBlob.slice(0, 4).text();
             let outlineFormat = "";
             switch (sfntVersion) {
               case "\x00\x01\x00\x00":
@@ -663,21 +663,20 @@ class PWA {
       if ("queryLocalFonts" in window) {
         // Supported.
         if (config && config.postscriptNames) {
-          const fonts = await window.queryLocalFonts({ postscriptNames: config.postscriptNames });
-
+          const fonts: FontData[] = await window.queryLocalFonts({ postscriptNames: config.postscriptNames });
           return {
             ok: true,
             message: "Fonts access",
             fonts,
-            outlineFormats: config.accessSFNT ? await getSFNT(fonts) : [],
+            outlineFormats: config.sfnt ? await getSFNT(fonts) : [],
           };
         } else {
-          const fonts = await window.queryLocalFonts();
+          const fonts: FontData[] = await window.queryLocalFonts();
           return {
             ok: true,
             message: "Fonts access",
             fonts,
-            outlineFormats: config && config.accessSFNT ? await getSFNT(fonts) : [],
+            outlineFormats: config && config.sfnt ? await getSFNT(fonts) : [],
           };
         }
       } else {

--- a/packages/pwafire/src/pwa/index.ts
+++ b/packages/pwafire/src/pwa/index.ts
@@ -625,7 +625,7 @@ class PWA {
 
   /**
    * Access local device fonts.
-   * @method localFontsAccess
+   * @method accessFonts
    */
   async accessFonts(config?: { postscriptNames?: string[]; sfnt?: boolean }) {
     try {

--- a/packages/pwafire/src/types.d.ts
+++ b/packages/pwafire/src/types.d.ts
@@ -28,4 +28,12 @@ declare var BarcodeDetector: {
   getSupportedFormats: () => any;
 };
 
+interface FontData {
+  postscriptName: string;
+  fullName: string;
+  family: string;
+  style: string;
+  blob: any;
+}
+
 declare var IdleDetector: { new (): any; requestPermission: () => any };


### PR DESCRIPTION
### Font Access

Allows you to access the user's locally installed fonts and obtain low-level details about them.

#### Call the accessFonts method on pwa

```js
const res = await pwa.accessFonts();
if (res.ok) {
  // Do something.
  const fonts = res.fonts;
} else {
  // Do something.
}
```

#### Accessing SFNT data

```js
const res = await pwa.accessFonts({
  sfnt: true,
});
if (res.ok) {
  // Do something with the sfnt data.
  const sfntFormats = res.sfnt;
} else {
  // Do something.
}
```

### Get subset of fonts

You can also filter them based on the `PostScript` names by adding a postscriptNames parameter, an array of strings.

```js
const res = await pwa.accessFonts({
  postscriptNames: ["Verdana", "Verdana-Bold", "Verdana-Italic"],
});
if (res.ok) {
  // Do something.
  const fonts = res.fonts;
} else {
  // Do something.
}
```