### PR TITLE
feature/web otp

### DIFF
--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -514,14 +514,15 @@ Verify phone numbers on the web with the WebOTP API, which allows you to receive
 #### Call the webOTP method on pwa
 
 ```js
-const res = await pwa.webOTP();
-// Do something with the result.
-if (res.ok) {
-  // Do something.
-  const code = res.code;
-} else {
-  // Do something.
-}
+await pwa.webOTP((res) => {
+  // Do something with the result.
+  if (res.ok) {
+    // Do something.
+    const code = res.code;
+  } else {
+    // Do something.
+  }
+});
 ```
 
 ### Font Access

--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -40,7 +40,7 @@ if (res.ok) {
 }
 ```
 
-#### Do something with the response returned for e.g copyText;
+#### Do something with the response returned for e.g copyText
 
 ```js
 // Copy text
@@ -264,7 +264,7 @@ pwa.Notification(data);
 
 Provide an installation step **type** (`before, installed or install`), and a **callback** function as a parameters to the **Install** method on pwa . This is a new feature in v4.0.7+
 
-#### Installation steps;
+#### Installation steps
 
 - Step `installed` => Check if the app is installed, e.g for react it'd be:
 
@@ -502,6 +502,23 @@ const res = await pwa.barcodeDetector({ image: image, format: "qr_code" });
 if (res.ok) {
   // Do something.
   const barcodes = res.barcodes;
+} else {
+  // Do something.
+}
+```
+
+### Web OTP API
+
+Verify phone numbers on the web with the WebOTP API, which allows you to receive one-time passwords (OTPs) from the SMS message and automatically fill them into the form.
+
+#### Call the webOTP method on pwa
+
+```js
+const res = await pwa.webOTP();
+// Do something with the result.
+if (res.ok) {
+  // Do something.
+  const code = res.code;
 } else {
   // Do something.
 }

--- a/packages/pwafire/README.md
+++ b/packages/pwafire/README.md
@@ -507,7 +507,7 @@ if (res.ok) {
 }
 ```
 
-### Web OTP API
+### Web OTP
 
 Verify phone numbers on the web with the WebOTP API, which allows you to receive one-time passwords (OTPs) from the SMS message and automatically fill them into the form.
 

--- a/packages/pwafire/package-lock.json
+++ b/packages/pwafire/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pwafire",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pwafire",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^14.6.0"

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "5.0.3-alpha-1",
+  "version": "5.0.4",
   "description": "Progressive Web App API of APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "5.0.3-alpha",
+  "version": "5.0.3-alpha-1",
   "description": "Progressive Web App API of APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "5.0.2",
+  "version": "5.0.3-alpha",
   "description": "Progressive Web App API of APIs",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/pwafire/src/types.d.ts
+++ b/packages/pwafire/src/types.d.ts
@@ -36,4 +36,17 @@ interface FontData {
   blob: any;
 }
 
+interface OTPCredential extends Credential {
+  code: string;
+  type: "otp";
+  otp: {
+    transport: "sms" | "email";
+    code: string;
+  };
+}
+
+interface OTPCredentialOptions extends CredentialRequestOptions {
+  otp: { transport: string[] };
+}
+
 declare var IdleDetector: { new (): any; requestPermission: () => any };


### PR DESCRIPTION
### Web OTP API

Verify phone numbers on the web with the WebOTP API, which allows you to receive one-time passwords (OTPs) from the SMS message and automatically fill them into the form.

#### Call the webOTP method on pwa

```js
await pwa.webOTP((res) => {
  // Do something with the result.
  if (res.ok) {
    // Do something.
    const code = res.code;
  } else {
    // Do something.
  }
});
```