### PR TITLE
docs: Add PR and release summary guidelines

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -40,6 +40,43 @@ feat(notifications) - add support for notification actions
 - `github` - GitHub-specific changes
 - Module names: `badging`, `clipboard`, `lazy-load`, etc.
 
+### PR and Release Summaries
+
+**Keep it SHORT and focused on KEY things only:**
+
+**PR Description:**
+- Brief overview (2-3 sentences)
+- Key features/changes (bullet points, max 5-7 items)
+- Breaking changes (if any)
+- No lengthy explanations or redundant details
+
+**Release Notes:**
+- Highlight main features only
+- Code examples for new APIs (minimal, essential only)
+- Installation/upgrade instructions (if needed)
+- Link to full changelog
+- Avoid verbose explanations
+
+**Example (Good):**
+```markdown
+## What's New
+- Add Summarizer API (batch + streaming)
+- Add Translator API with language pairs
+- Status codes for error handling
+
+## Install
+npm install pwafire@6.1.0
+```
+
+**Example (Bad):**
+```markdown
+## What's New
+This PR adds support for Chrome's built-in Web AI APIs...
+[3 paragraphs of explanation]
+[Detailed code examples for every scenario]
+[Long technical descriptions]
+```
+
 ### Naming Conventions
 
 #### Functions & Variables


### PR DESCRIPTION
Add guidelines to agents.md for keeping PR and release summaries concise:

- Focus on key things only
- Avoid lengthy explanations
- Provide good vs bad examples
- Essential code examples only

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>