### PR TITLE
chore(docs): sync readme badges and remove security badge

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -2,6 +2,7 @@
 
 Une bibliothèque moderne et modulaire pour créer facilement des Applications Web Progressives. PWAFire fournit un ensemble complet d'APIs et d'utilitaires pour améliorer vos applications web avec des capacités PWA. Construit sur Project Fugu, PWAFire aide à combler l'écart entre les capacités web et natives.
 
+[![CI](https://github.com/pwafire/pwafire/workflows/CI/badge.svg)](https://github.com/pwafire/pwafire/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/pwafire.svg)](https://badge.fury.io/js/pwafire)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation](https://img.shields.io/badge/Docs-docs.pwafire.org-blue)](https://docs.pwafire.org/get-started)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Modern PWA APIs for building Progressive Web Apps with ease.
 
 [![CI](https://github.com/pwafire/pwafire/workflows/CI/badge.svg)](https://github.com/pwafire/pwafire/actions/workflows/ci.yml)
-[![Security](https://github.com/pwafire/pwafire/workflows/Security/badge.svg)](https://github.com/pwafire/pwafire/actions/workflows/security.yml)
 [![npm version](https://badge.fury.io/js/pwafire.svg)](https://badge.fury.io/js/pwafire)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation](https://img.shields.io/badge/Docs-docs.pwafire.org-blue)](https://docs.pwafire.org/get-started)


### PR DESCRIPTION
## Summary
- Remove deprecated Security workflow badge from README.md
- Add CI badge to French README for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)