### PR TITLE
fix(ci): resolve rollup optional dependencies issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: packages/pwafire/package-lock.json
 
-      - run: npm ci
+      - name: Clean install dependencies
+        run: |
+          npm cache clean --force
+          npm ci --force
+
       - run: npm run verify
 
       # Publish using OIDC trusted publisher (no token needed!)


### PR DESCRIPTION
## Summary
Fixed the Rollup module error in the publish pipeline by cleaning npm cache and using the --force flag during installation.

## Changes
- Added `npm cache clean --force` before dependency installation
- Changed `npm ci` to `npm ci --force` to properly handle optional dependencies
- This resolves the known npm bug: https://github.com/npm/cli/issues/4828

## Error Fixed
```
Error: Cannot find module @rollup/rollup-linux-x64-gnu
```

## Test plan
- [x] Commit passes local tests
- [ ] Will be verified in next publish workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)