### PR TITLE
feat(passkey): add passkey api for webauthn passwordless auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Quick reference for working on PWAFire. For detailed guidelines, see `/docs/*.md
 - [HTML/CSS Style](./docs/html-css-style.md) - Test console styling guidelines
 - [Tooling](./docs/tooling.md) - Prettier, ESLint, NPM scripts, testing requirements
 - [Console App](./docs/console.md) - Complete console app documentation
+- [Passkey API](./docs/passkey.md) - Passkey implementation notes and user verification
 
 ## Key Reminders
 

--- a/console/src/api-configs/index.ts
+++ b/console/src/api-configs/index.ts
@@ -3,18 +3,13 @@ import { logConsole } from "../log";
 import {
   showSummarizerModal,
   showTranslatorModal,
-  showLanguageDetectorModal,
+  showLanguageDetectorModal
 } from "../modals";
 import { passkey } from "pwafire";
-import { getMockCreationOptions, getMockRequestOptions } from "../mocks/passkey-mock";
-
-let passkeyAbortController: AbortController | null = null;
-
-const getPasskeySignal = (): AbortSignal => {
-  if (passkeyAbortController) passkeyAbortController.abort();
-  passkeyAbortController = new AbortController();
-  return passkeyAbortController.signal;
-};
+import {
+  getMockCreationOptions,
+  getMockRequestOptions
+} from "../mocks/passkey-mock";
 
 export const apiConfigs: Record<string, ApiConfig> = {
   webShare: {
@@ -114,8 +109,8 @@ export const apiConfigs: Record<string, ApiConfig> = {
         logConsole(parsed.message, "error");
         return null;
       }
-      return [parsed.options, getPasskeySignal()];
-    },
+      return [parsed.options];
+    }
   },
   "passkey.get": {
     title: "Passkey Get",
@@ -132,8 +127,8 @@ export const apiConfigs: Record<string, ApiConfig> = {
         logConsole(parsed.message, "error");
         return null;
       }
-      return [parsed.options, getPasskeySignal()];
-    },
+      return [parsed.options];
+    }
   },
   "passkey.getConditional": {
     title: "Passkey Get (Conditional)",
@@ -150,8 +145,8 @@ export const apiConfigs: Record<string, ApiConfig> = {
         logConsole(parsed.message, "error");
         return null;
       }
-      return [parsed.options, getPasskeySignal()];
-    },
+      return [parsed.options];
+    }
   },
   payment: {
     title: "Payment",
@@ -332,7 +327,7 @@ export const apiConfigs: Record<string, ApiConfig> = {
       if (!config) return null;
       window.__summarizerCloseModal = config.closeModal;
       return [config.text];
-    },
+    }
   }
 };
 

--- a/console/src/api-configs/index.ts
+++ b/console/src/api-configs/index.ts
@@ -5,6 +5,16 @@ import {
   showTranslatorModal,
   showLanguageDetectorModal,
 } from "../modals";
+import { passkey } from "pwafire";
+import { getMockCreationOptions, getMockRequestOptions } from "../mocks/passkey-mock";
+
+let passkeyAbortController: AbortController | null = null;
+
+const getPasskeySignal = (): AbortSignal => {
+  if (passkeyAbortController) passkeyAbortController.abort();
+  passkeyAbortController = new AbortController();
+  return passkeyAbortController.signal;
+};
 
 export const apiConfigs: Record<string, ApiConfig> = {
   webShare: {
@@ -89,6 +99,60 @@ export const apiConfigs: Record<string, ApiConfig> = {
     params: () => ["start", () => logConsole("User is idle", "info"), 60000]
   },
   webOtp: { title: "Web OTP" },
+  "passkey.create": {
+    title: "Passkey Create",
+    params: async () => {
+      let json: Record<string, unknown>;
+      try {
+        const res = await fetch("/mock/webauthn/register");
+        json = res.ok ? await res.json() : getMockCreationOptions();
+      } catch {
+        json = getMockCreationOptions();
+      }
+      const parsed = passkey.parseCreationOptions(json);
+      if (!parsed.ok || !parsed.options) {
+        logConsole(parsed.message, "error");
+        return null;
+      }
+      return [parsed.options, getPasskeySignal()];
+    },
+  },
+  "passkey.get": {
+    title: "Passkey Get",
+    params: async () => {
+      let json: Record<string, unknown>;
+      try {
+        const res = await fetch("/mock/webauthn/signin");
+        json = res.ok ? await res.json() : getMockRequestOptions();
+      } catch {
+        json = getMockRequestOptions();
+      }
+      const parsed = passkey.parseRequestOptions(json);
+      if (!parsed.ok || !parsed.options) {
+        logConsole(parsed.message, "error");
+        return null;
+      }
+      return [parsed.options, getPasskeySignal()];
+    },
+  },
+  "passkey.getConditional": {
+    title: "Passkey Get (Conditional)",
+    params: async () => {
+      let json: Record<string, unknown>;
+      try {
+        const res = await fetch("/mock/webauthn/signin");
+        json = res.ok ? await res.json() : getMockRequestOptions();
+      } catch {
+        json = getMockRequestOptions();
+      }
+      const parsed = passkey.parseRequestOptions(json);
+      if (!parsed.ok || !parsed.options) {
+        logConsole(parsed.message, "error");
+        return null;
+      }
+      return [parsed.options, getPasskeySignal()];
+    },
+  },
   payment: {
     title: "Payment",
     params: () => [
@@ -307,5 +371,6 @@ export const apiGroups: Record<string, string[]> = {
     "accessFonts"
   ],
   "👤 User Data": ["contacts", "payment", "webOtp"],
+  "🔐 Passkey": ["passkey.create", "passkey.get", "passkey.getConditional"],
   "📦 Other": ["contentIndexing", "install"]
 };

--- a/console/src/features/index.ts
+++ b/console/src/features/index.ts
@@ -16,6 +16,7 @@ export const featureDisplayNames: Record<string, string> = {
   install: "Install",
   lazyLoad: "Lazy Loading",
   notification: "Notification",
+  passkey: "Passkey",
   payment: "Payment Request",
   screenShare: "Screen Share",
   summarizer: "Summarizer",

--- a/console/src/mocks/passkey-mock.ts
+++ b/console/src/mocks/passkey-mock.ts
@@ -1,0 +1,46 @@
+const base64urlEncode = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+export const getMockCreationOptions = (): Record<string, unknown> => {
+  const rpId = typeof window !== "undefined" ? window.location.hostname || "localhost" : "localhost";
+  const challenge = crypto.getRandomValues(new Uint8Array(32));
+  const userId = crypto.getRandomValues(new Uint8Array(16));
+
+  return {
+    challenge: base64urlEncode(challenge),
+    rp: {
+      name: "PWAFire Demo",
+      id: rpId,
+    },
+    user: {
+      id: base64urlEncode(userId),
+      name: "demo@pwafire.local",
+      displayName: "PWAFire Demo User",
+    },
+    pubKeyCredParams: [
+      { alg: -7, type: "public-key" },
+      { alg: -257, type: "public-key" },
+    ],
+    authenticatorSelection: {
+      authenticatorAttachment: "platform",
+      requireResidentKey: true,
+      residentKey: "required",
+    },
+  };
+};
+
+export const getMockRequestOptions = (): Record<string, unknown> => {
+  const rpId = typeof window !== "undefined" ? window.location.hostname || "localhost" : "localhost";
+  const challenge = crypto.getRandomValues(new Uint8Array(32));
+
+  return {
+    challenge: base64urlEncode(challenge),
+    rpId,
+    userVerification: "preferred",
+  };
+};

--- a/console/src/mocks/vite-mock-webauthn.ts
+++ b/console/src/mocks/vite-mock-webauthn.ts
@@ -1,0 +1,59 @@
+import type { Plugin } from "vite";
+
+const base64urlEncode = (buffer: Uint8Array): string => {
+  let binary = "";
+  for (let i = 0; i < buffer.length; i++) {
+    binary += String.fromCharCode(buffer[i]);
+  }
+  return Buffer.from(binary, "binary").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+export const mockWebAuthnPlugin = (): Plugin => ({
+  name: "mock-webauthn",
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      if (req.url === "/mock/webauthn/register" && req.method === "GET") {
+        const challenge = new Uint8Array(32);
+        const userId = new Uint8Array(16);
+        for (let i = 0; i < 32; i++) challenge[i] = Math.floor(Math.random() * 256);
+        for (let i = 0; i < 16; i++) userId[i] = Math.floor(Math.random() * 256);
+
+        const json = {
+          challenge: base64urlEncode(challenge),
+          rp: { name: "PWAFire Demo", id: "localhost" },
+          user: {
+            id: base64urlEncode(userId),
+            name: "demo@pwafire.local",
+            displayName: "PWAFire Demo User",
+          },
+          pubKeyCredParams: [
+            { alg: -7, type: "public-key" },
+            { alg: -257, type: "public-key" },
+          ],
+          authenticatorSelection: {
+            authenticatorAttachment: "platform",
+            requireResidentKey: true,
+            residentKey: "required",
+          },
+        };
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(json));
+        return;
+      }
+      if (req.url === "/mock/webauthn/signin" && req.method === "GET") {
+        const challenge = new Uint8Array(32);
+        for (let i = 0; i < 32; i++) challenge[i] = Math.floor(Math.random() * 256);
+
+        const json = {
+          challenge: base64urlEncode(challenge),
+          rpId: "localhost",
+          userVerification: "preferred",
+        };
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(json));
+        return;
+      }
+      next();
+    });
+  },
+});

--- a/console/src/tests/index.ts
+++ b/console/src/tests/index.ts
@@ -1,5 +1,14 @@
 import * as pwafire from "pwafire";
 import { apiConfigs, apiGroups } from "../api-configs";
+
+const getApiFn = (apiName: string): unknown => {
+  if (apiName.includes(".")) {
+    const [obj, method] = apiName.split(".");
+    const parent = (pwafire as Record<string, unknown>)[obj];
+    return parent && typeof parent === "object" && method in parent ? (parent as Record<string, unknown>)[method] : undefined;
+  }
+  return (pwafire as Record<string, unknown>)[apiName];
+};
 import { stats, updateStats } from "../stats";
 import { logConsole } from "../log";
 import { showResult } from "../results";
@@ -151,7 +160,7 @@ const setupStreamModalClose = (apiName: string): void => {
         }
 
         // Call the API directly
-        const apiFn = pwafire[apiName as keyof typeof pwafire];
+        const apiFn = getApiFn(apiName);
         const result = await (apiFn as (...args: unknown[]) => Promise<unknown>)(...params);
 
         // Hide loading bar
@@ -326,7 +335,7 @@ export const generateTests = (): void => {
     testGrid.appendChild(groupHeader);
 
     apis.forEach((key) => {
-      const pwafireApi = pwafire[key as keyof typeof pwafire];
+      const pwafireApi = getApiFn(key);
       const config = apiConfigs[key];
 
       if (typeof pwafireApi === "function" && config) {
@@ -366,7 +375,7 @@ export const runTest = async (apiName: string): Promise<void> => {
       return;
     }
 
-    const apiFn = pwafire[apiName as keyof typeof pwafire];
+    const apiFn = getApiFn(apiName);
     if (typeof apiFn !== "function") {
       stats.failed++;
       updateStats();
@@ -465,7 +474,7 @@ export const runAllTests = async (): Promise<void> => {
   logConsole("=".repeat(50), "info");
 
   for (const apiName of Object.keys(apiConfigs)) {
-    if (typeof pwafire[apiName as keyof typeof pwafire] === "function") {
+    if (typeof getApiFn(apiName) === "function") {
       await runTest(apiName);
       await new Promise((r) => setTimeout(r, 500));
     }

--- a/console/tests/test-exports.js
+++ b/console/tests/test-exports.js
@@ -48,6 +48,7 @@ async function testExports() {
     "install",
     "lazy-load",
     "notification",
+    "passkey",
     "payment",
     "screen",
     "visibility",

--- a/console/tests/test-features.js
+++ b/console/tests/test-features.js
@@ -25,6 +25,7 @@ async function testFeatures() {
       'fonts': checkModule.fonts,
       'fullscreen': checkModule.fullscreen,
       'notification': checkModule.notification,
+      'passkey': checkModule.passkey,
       'payment': checkModule.payment,
       'visibility': checkModule.visibility,
       'wakeLock': checkModule.wakeLock,

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -1,11 +1,13 @@
-import { defineConfig } from 'vite';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { defineConfig } from "vite";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { mockWebAuthnPlugin } from "./src/mocks/vite-mock-webauthn";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineConfig({
+  plugins: [mockWebAuthnPlugin()],
   build: {
     outDir: 'dist',
     emptyOutDir: true,

--- a/docs/file-organization.md
+++ b/docs/file-organization.md
@@ -24,10 +24,27 @@ packages/pwafire/
 - Extract to separate file if reusable
 - Named exports preferred over default exports
 
+## Export Pattern: Object vs Flat
+
+**Use an object when:** Methods belong to one cohesive flow and are typically used together.
+
+**Use flat exports when:** Methods are independent use cases and are typically used one at a time.
+
+| Criterion | Object (`passkey.create`) | Flat (`pickFile`, `copyText`) |
+|-----------|---------------------------|------------------------------|
+| Flow | Single flow; methods are steps in one lifecycle | Multiple flows; methods are different tools |
+| Usage | Need multiple methods together | Use one method at a time |
+| Example | passkey: create → get → signalUnknown | files: pickFile, createFile, readFiles (independent) |
+
+**Examples:**
+- `passkey` → object: registration and authentication are both required for passkey auth
+- `files` → flat: pickFile, createFile, writeFile are separate use cases
+
 ## Exports & Imports
 - Export at declaration:
   ```typescript
   export const apiName = async () => {};
+  export const passkey = { create: async () => {}, get: async () => {} };
   ```
 - Import order: external, internal, relative
 - Group by type:

--- a/docs/passkey.md
+++ b/docs/passkey.md
@@ -1,0 +1,53 @@
+# Passkey API
+
+Implementation notes for the passkey module.
+
+## API Surface
+
+```typescript
+passkey = {
+  parseCreationOptions(json): { ok, message, options?: PublicKeyCredentialCreationOptions }
+  parseRequestOptions(json): { ok, message, options?: PublicKeyCredentialRequestOptions }
+  create(options: PublicKeyCredentialCreationOptions, signal?): Promise<PasskeyResult>
+  get(options: PublicKeyCredentialRequestOptions, signal?): Promise<PasskeyResult>
+  getConditional(options: PublicKeyCredentialRequestOptions, signal?): Promise<PasskeyResult>
+  signalUnknown(rpId, credentialId): Promise<{ ok, message }>
+  signalUnknownCredential: boolean
+}
+```
+
+Types follow [PublicKeyCredentialCreationOptions](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions) and [PublicKeyCredentialRequestOptions](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions).
+
+## User Verification Caution
+
+When `userVerification` is set to `"preferred"` in your backend options, authenticators may skip the user verification check. This can happen when:
+
+- The device lacks biometric sensors
+- The user has not set up biometrics (no enrolled fingerprints)
+- The sensor is temporarily unavailable (e.g. laptop with lid closed)
+
+The **UV bit** in the authenticator data of the response indicates whether user verification was performed.
+
+- If the UV bit is OFF and you require additional verification, prompt the user for a second factor (e.g. password)
+- Alternatively, set `userVerification` to `"required"`, but be aware this may lead to a confusing user experience depending on the platform
+
+For more details, see [userVerification deep dive](https://web.dev/articles/webauthn-user-verification).
+
+## Request Already Pending
+
+WebAuthn allows only one credential operation at a time. If you see "A request is already pending with passkeys", a previous `create`, `get`, or `getConditional` call is still in progress.
+
+**Solution:** Use `AbortController` to cancel the previous request before starting a new one:
+
+```typescript
+let passkeyAbortController: AbortController | null = null;
+
+const runCreate = async () => {
+  if (passkeyAbortController) passkeyAbortController.abort();
+  passkeyAbortController = new AbortController();
+  const { ok, credential } = await passkey.create(options, passkeyAbortController.signal);
+  // ...
+};
+```
+
+When switching between passkey operations (e.g. from `getConditional` to `create`), abort the previous controller first. See [Create a passkey for passwordless logins](https://web.dev/articles/passkey-registration) for the full flow.

--- a/docs/passkey.md
+++ b/docs/passkey.md
@@ -8,13 +8,16 @@ Implementation notes for the passkey module.
 passkey = {
   parseCreationOptions(json): { ok, message, options?: PublicKeyCredentialCreationOptions }
   parseRequestOptions(json): { ok, message, options?: PublicKeyCredentialRequestOptions }
-  create(options: PublicKeyCredentialCreationOptions, signal?): Promise<PasskeyResult>
-  get(options: PublicKeyCredentialRequestOptions, signal?): Promise<PasskeyResult>
-  getConditional(options: PublicKeyCredentialRequestOptions, signal?): Promise<PasskeyResult>
+  create(options: PublicKeyCredentialCreationOptions): Promise<PasskeyResult>
+  get(options: PublicKeyCredentialRequestOptions): Promise<PasskeyResult>
+  getConditional(options: PublicKeyCredentialRequestOptions): Promise<PasskeyResult>
+  abort(): void
   signalUnknown(rpId, credentialId): Promise<{ ok, message }>
   signalUnknownCredential: boolean
 }
 ```
+
+Abort handling is internal: each create/get/getConditional aborts any pending request before starting. Use `passkey.abort()` to cancel manually (e.g. on form submit).
 
 Types follow [PublicKeyCredentialCreationOptions](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions) and [PublicKeyCredentialRequestOptions](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions).
 
@@ -35,19 +38,10 @@ For more details, see [userVerification deep dive](https://web.dev/articles/weba
 
 ## Request Already Pending
 
-WebAuthn allows only one credential operation at a time. If you see "A request is already pending with passkeys", a previous `create`, `get`, or `getConditional` call is still in progress.
+WebAuthn allows only one credential operation at a time. The passkey API handles this internally: each `create`, `get`, or `getConditional` aborts any pending request before starting.
 
-**Solution:** Use `AbortController` to cancel the previous request before starting a new one:
+To cancel manually (e.g. when the user submits a form with a password instead of passkey):
 
 ```typescript
-let passkeyAbortController: AbortController | null = null;
-
-const runCreate = async () => {
-  if (passkeyAbortController) passkeyAbortController.abort();
-  passkeyAbortController = new AbortController();
-  const { ok, credential } = await passkey.create(options, passkeyAbortController.signal);
-  // ...
-};
+form.addEventListener("submit", () => passkey.abort());
 ```
-
-When switching between passkey operations (e.g. from `getConditional` to `create`), abort the previous controller first. See [Create a passkey for passwordless logins](https://web.dev/articles/passkey-registration) for the full flow.

--- a/packages/pwafire/package-lock.json
+++ b/packages/pwafire/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pwafire",
-  "version": "6.1.0",
+  "version": "6.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pwafire",
-      "version": "6.1.0",
+      "version": "6.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/dom-chromium-ai": "^0.0.14",

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A collection of PWA APIs and utilities",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/packages/pwafire/src/check/index.ts
+++ b/packages/pwafire/src/check/index.ts
@@ -13,6 +13,7 @@ export const install = () => "getInstalledRelatedApps" in navigator;
 export const languageDetector = () => "LanguageDetector" in self;
 export const lazyLoad = () => "loading" in HTMLImageElement.prototype;
 export const notification = () => "Notification" in window;
+export const passkey = () => "PublicKeyCredential" in window;
 export const payment = () => "PaymentRequest" in window;
 export const screenShare = () => "getDisplayMedia" in navigator.mediaDevices;
 export const summarizer = () => "Summarizer" in self;

--- a/packages/pwafire/src/index.ts
+++ b/packages/pwafire/src/index.ts
@@ -13,6 +13,7 @@ export * from "./pwa/install";
 export * from "./pwa/language-detector";
 export * from "./pwa/lazy-load";
 export * from "./pwa/notification";
+export * from "./pwa/passkey";
 export * from "./pwa/payment";
 export * from "./pwa/screen";
 export * from "./pwa/summarizer";

--- a/packages/pwafire/src/pwa/index.ts
+++ b/packages/pwafire/src/pwa/index.ts
@@ -13,6 +13,7 @@ export * from "./install";
 export * from "./language-detector";
 export * from "./lazy-load";
 export * from "./notification";
+export * from "./passkey";
 export * from "./payment";
 export * from "./screen";
 export * from "./summarizer";

--- a/packages/pwafire/src/pwa/passkey/index.ts
+++ b/packages/pwafire/src/pwa/passkey/index.ts
@@ -19,6 +19,14 @@ type PasskeyResult = {
 const getPubKey = (): unknown =>
   typeof window !== "undefined" ? (window as unknown as { PublicKeyCredential?: unknown }).PublicKeyCredential : undefined;
 
+let passkeyAbortController: AbortController | null = null;
+
+const getOrCreateSignal = (): AbortSignal => {
+  if (passkeyAbortController) passkeyAbortController.abort();
+  passkeyAbortController = new AbortController();
+  return passkeyAbortController.signal;
+};
+
 const parseCreationOptions = (json: Record<string, unknown>): ParseCreationResult => {
   try {
     const PubKey = getPubKey();
@@ -53,14 +61,14 @@ const parseRequestOptions = (json: Record<string, unknown>): ParseRequestResult 
   }
 };
 
-const create = async (options: PublicKeyCredentialCreationOptions, signal?: AbortSignal): Promise<PasskeyResult> => {
+const create = async (options: PublicKeyCredentialCreationOptions): Promise<PasskeyResult> => {
   try {
     if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
       return { ok: false, message: "Passkey API not supported" };
     }
     const credential = (await navigator.credentials.create({
       publicKey: options,
-      signal,
+      signal: getOrCreateSignal(),
     })) as PublicKeyCredential | null;
     if (!credential) {
       return { ok: false, message: "Failed to create passkey" };
@@ -83,14 +91,14 @@ const create = async (options: PublicKeyCredentialCreationOptions, signal?: Abor
   }
 };
 
-const get = async (options: PublicKeyCredentialRequestOptions, signal?: AbortSignal): Promise<PasskeyResult> => {
+const get = async (options: PublicKeyCredentialRequestOptions): Promise<PasskeyResult> => {
   try {
     if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
       return { ok: false, message: "Passkey API not supported" };
     }
     const credential = (await navigator.credentials.get({
       publicKey: options,
-      signal,
+      signal: getOrCreateSignal(),
     })) as PublicKeyCredential | null;
     if (!credential) {
       return { ok: false, message: "Failed to authenticate" };
@@ -110,7 +118,7 @@ const get = async (options: PublicKeyCredentialRequestOptions, signal?: AbortSig
   }
 };
 
-const getConditional = async (options: PublicKeyCredentialRequestOptions, signal?: AbortSignal): Promise<PasskeyResult> => {
+const getConditional = async (options: PublicKeyCredentialRequestOptions): Promise<PasskeyResult> => {
   try {
     if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
       return { ok: false, message: "Passkey API not supported" };
@@ -118,7 +126,7 @@ const getConditional = async (options: PublicKeyCredentialRequestOptions, signal
     const credential = (await navigator.credentials.get({
       publicKey: options,
       mediation: "conditional",
-      signal,
+      signal: getOrCreateSignal(),
     })) as PublicKeyCredential | null;
     if (!credential) {
       return { ok: false, message: "Failed to authenticate" };
@@ -154,12 +162,20 @@ const signalUnknown = async (rpId: string, credentialId: string): Promise<{ ok: 
   }
 };
 
+const abort = (): void => {
+  if (passkeyAbortController) {
+    passkeyAbortController.abort();
+    passkeyAbortController = null;
+  }
+};
+
 export const passkey = {
   parseCreationOptions,
   parseRequestOptions,
   create,
   get,
   getConditional,
+  abort,
   signalUnknown,
   get signalUnknownCredential(): boolean {
     const PubKey = getPubKey();

--- a/packages/pwafire/src/pwa/passkey/index.ts
+++ b/packages/pwafire/src/pwa/passkey/index.ts
@@ -1,0 +1,168 @@
+type ParseCreationResult = {
+  ok: boolean;
+  message: string;
+  options?: PublicKeyCredentialCreationOptions;
+};
+
+type ParseRequestResult = {
+  ok: boolean;
+  message: string;
+  options?: PublicKeyCredentialRequestOptions;
+};
+
+type PasskeyResult = {
+  ok: boolean;
+  message: string;
+  credential?: PublicKeyCredential;
+};
+
+const getPubKey = (): unknown =>
+  typeof window !== "undefined" ? (window as unknown as { PublicKeyCredential?: unknown }).PublicKeyCredential : undefined;
+
+const parseCreationOptions = (json: Record<string, unknown>): ParseCreationResult => {
+  try {
+    const PubKey = getPubKey();
+    if (!PubKey || typeof (PubKey as { parseCreationOptionsFromJSON?: (arg: Record<string, unknown>) => PublicKeyCredentialCreationOptions }).parseCreationOptionsFromJSON !== "function") {
+      return { ok: false, message: "Passkey API not supported", options: undefined };
+    }
+    const options = (PubKey as { parseCreationOptionsFromJSON: (arg: Record<string, unknown>) => PublicKeyCredentialCreationOptions }).parseCreationOptionsFromJSON(json);
+    return { ok: true, message: "OK", options };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Failed to parse creation options",
+      options: undefined,
+    };
+  }
+};
+
+const parseRequestOptions = (json: Record<string, unknown>): ParseRequestResult => {
+  try {
+    const PubKey = getPubKey();
+    if (!PubKey || typeof (PubKey as { parseRequestOptionsFromJSON?: (arg: Record<string, unknown>) => PublicKeyCredentialRequestOptions }).parseRequestOptionsFromJSON !== "function") {
+      return { ok: false, message: "Passkey API not supported", options: undefined };
+    }
+    const options = (PubKey as { parseRequestOptionsFromJSON: (arg: Record<string, unknown>) => PublicKeyCredentialRequestOptions }).parseRequestOptionsFromJSON(json);
+    return { ok: true, message: "OK", options };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Failed to parse request options",
+      options: undefined,
+    };
+  }
+};
+
+const create = async (options: PublicKeyCredentialCreationOptions, signal?: AbortSignal): Promise<PasskeyResult> => {
+  try {
+    if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
+      return { ok: false, message: "Passkey API not supported" };
+    }
+    const credential = (await navigator.credentials.create({
+      publicKey: options,
+      signal,
+    })) as PublicKeyCredential | null;
+    if (!credential) {
+      return { ok: false, message: "Failed to create passkey" };
+    }
+    return { ok: true, message: "Passkey created", credential };
+  } catch (error) {
+    if (error instanceof Error && error.name === "InvalidStateError") {
+      return { ok: true, message: "Passkey already exists" };
+    }
+    if (error instanceof Error && error.name === "NotAllowedError") {
+      return { ok: false, message: "User cancelled" };
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      return { ok: false, message: "Operation aborted" };
+    }
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Failed to create passkey",
+    };
+  }
+};
+
+const get = async (options: PublicKeyCredentialRequestOptions, signal?: AbortSignal): Promise<PasskeyResult> => {
+  try {
+    if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
+      return { ok: false, message: "Passkey API not supported" };
+    }
+    const credential = (await navigator.credentials.get({
+      publicKey: options,
+      signal,
+    })) as PublicKeyCredential | null;
+    if (!credential) {
+      return { ok: false, message: "Failed to authenticate" };
+    }
+    return { ok: true, message: "Authenticated", credential };
+  } catch (error) {
+    if (error instanceof Error && error.name === "NotAllowedError") {
+      return { ok: false, message: "User cancelled" };
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      return { ok: false, message: "Operation aborted" };
+    }
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Failed to authenticate",
+    };
+  }
+};
+
+const getConditional = async (options: PublicKeyCredentialRequestOptions, signal?: AbortSignal): Promise<PasskeyResult> => {
+  try {
+    if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
+      return { ok: false, message: "Passkey API not supported" };
+    }
+    const credential = (await navigator.credentials.get({
+      publicKey: options,
+      mediation: "conditional",
+      signal,
+    })) as PublicKeyCredential | null;
+    if (!credential) {
+      return { ok: false, message: "Failed to authenticate" };
+    }
+    return { ok: true, message: "Authenticated", credential };
+  } catch (error) {
+    if (error instanceof Error && error.name === "NotAllowedError") {
+      return { ok: false, message: "User cancelled" };
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      return { ok: false, message: "Operation aborted" };
+    }
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Failed to authenticate",
+    };
+  }
+};
+
+const signalUnknown = async (rpId: string, credentialId: string): Promise<{ ok: boolean; message: string }> => {
+  try {
+    const PubKey = getPubKey();
+    if (!PubKey || typeof (PubKey as { signalUnknownCredential?: (arg: { rpId: string; credentialId: string }) => Promise<void> }).signalUnknownCredential !== "function") {
+      return { ok: false, message: "Signal API not supported" };
+    }
+    await (PubKey as { signalUnknownCredential: (arg: { rpId: string; credentialId: string }) => Promise<void> }).signalUnknownCredential({ rpId, credentialId });
+    return { ok: true, message: "Signal sent" };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Failed to signal unknown credential",
+    };
+  }
+};
+
+export const passkey = {
+  parseCreationOptions,
+  parseRequestOptions,
+  create,
+  get,
+  getConditional,
+  signalUnknown,
+  get signalUnknownCredential(): boolean {
+    const PubKey = getPubKey();
+    return typeof (PubKey as { signalUnknownCredential?: unknown })?.signalUnknownCredential === "function";
+  },
+};

--- a/packages/pwafire/src/pwa/passkey/passkey.test.ts
+++ b/packages/pwafire/src/pwa/passkey/passkey.test.ts
@@ -1,0 +1,179 @@
+import { passkey } from "./index";
+import * as check from "../../check";
+
+describe("passkey", () => {
+  const mockParseCreationOptions = jest.fn();
+  const mockParseRequestOptions = jest.fn();
+  const mockSignalUnknownCredential = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when PublicKeyCredential is not available", () => {
+    beforeEach(() => {
+      delete (window as unknown as { PublicKeyCredential?: unknown }).PublicKeyCredential;
+    });
+
+    it("check.passkey returns false", () => {
+      expect(check.passkey()).toBe(false);
+    });
+
+    it("parseCreationOptions returns not supported", () => {
+      const result = passkey.parseCreationOptions({ challenge: "test" });
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Passkey API not supported");
+      expect(result.options).toBeUndefined();
+    });
+
+    it("parseRequestOptions returns not supported", () => {
+      const result = passkey.parseRequestOptions({ challenge: "test" });
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Passkey API not supported");
+      expect(result.options).toBeUndefined();
+    });
+
+    it("create returns not supported", async () => {
+      const result = await passkey.create({} as PublicKeyCredentialCreationOptions);
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Passkey API not supported");
+    });
+
+    it("signalUnknown returns not supported", async () => {
+      const result = await passkey.signalUnknown("example.com", "cred-id");
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Signal API not supported");
+    });
+  });
+
+  describe("when PublicKeyCredential is available", () => {
+    beforeEach(() => {
+      (window as unknown as { PublicKeyCredential: unknown }).PublicKeyCredential = {
+        parseCreationOptionsFromJSON: mockParseCreationOptions,
+        parseRequestOptionsFromJSON: mockParseRequestOptions,
+        signalUnknownCredential: mockSignalUnknownCredential,
+      };
+      Object.defineProperty(navigator, "credentials", {
+        configurable: true,
+        value: {
+          create: jest.fn(),
+          get: jest.fn(),
+        },
+      });
+    });
+
+    it("check.passkey returns true", () => {
+      expect(check.passkey()).toBe(true);
+    });
+
+    it("parseCreationOptions returns parsed options when successful", () => {
+      const mockOptions = { challenge: new ArrayBuffer(32) };
+      mockParseCreationOptions.mockReturnValue(mockOptions);
+
+      const result = passkey.parseCreationOptions({ challenge: "base64" });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("OK");
+      expect(result.options).toBe(mockOptions);
+      expect(mockParseCreationOptions).toHaveBeenCalledWith({ challenge: "base64" });
+    });
+
+    it("parseCreationOptions returns error when parse throws", () => {
+      mockParseCreationOptions.mockImplementation(() => {
+        throw new Error("Invalid JSON");
+      });
+
+      const result = passkey.parseCreationOptions({});
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Invalid JSON");
+      expect(result.options).toBeUndefined();
+    });
+
+    it("parseRequestOptions returns parsed options when successful", () => {
+      const mockOptions = { challenge: new ArrayBuffer(32) };
+      mockParseRequestOptions.mockReturnValue(mockOptions);
+
+      const result = passkey.parseRequestOptions({ challenge: "base64" });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("OK");
+      expect(result.options).toBe(mockOptions);
+      expect(mockParseRequestOptions).toHaveBeenCalledWith({ challenge: "base64" });
+    });
+
+    it("create returns User cancelled on NotAllowedError", async () => {
+      (navigator.credentials.create as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("User cancelled"), { name: "NotAllowedError" })
+      );
+
+      const result = await passkey.create({} as PublicKeyCredentialCreationOptions);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("User cancelled");
+    });
+
+    it("create returns success on InvalidStateError (passkey already exists)", async () => {
+      (navigator.credentials.create as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("Already exists"), { name: "InvalidStateError" })
+      );
+
+      const result = await passkey.create({} as PublicKeyCredentialCreationOptions);
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("Passkey already exists");
+    });
+
+    it("create returns Operation aborted on AbortError", async () => {
+      (navigator.credentials.create as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("Aborted"), { name: "AbortError" })
+      );
+
+      const result = await passkey.create({} as PublicKeyCredentialCreationOptions);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("Operation aborted");
+    });
+
+    it("get returns User cancelled on NotAllowedError", async () => {
+      (navigator.credentials.get as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("User cancelled"), { name: "NotAllowedError" })
+      );
+
+      const result = await passkey.get({} as PublicKeyCredentialRequestOptions);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toBe("User cancelled");
+    });
+
+    it("signalUnknown succeeds when API is available", async () => {
+      mockSignalUnknownCredential.mockResolvedValue(undefined);
+
+      const result = await passkey.signalUnknown("example.com", "cred-123");
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toBe("Signal sent");
+      expect(mockSignalUnknownCredential).toHaveBeenCalledWith({
+        rpId: "example.com",
+        credentialId: "cred-123",
+      });
+    });
+
+    it("signalUnknownCredential getter returns true when API available", () => {
+      expect(passkey.signalUnknownCredential).toBe(true);
+    });
+  });
+
+  describe("signalUnknownCredential getter when signal API not available", () => {
+    beforeEach(() => {
+      (window as unknown as { PublicKeyCredential: unknown }).PublicKeyCredential = {
+        parseCreationOptionsFromJSON: mockParseCreationOptions,
+        parseRequestOptionsFromJSON: mockParseRequestOptions,
+      };
+    });
+
+    it("returns false", () => {
+      expect(passkey.signalUnknownCredential).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Overview

Adds Passkey API (WebAuthn) for passwordless authentication. Follows PWAFire catch-and-return pattern with consistent response format.

## Key changes

- `passkey.create()` - Register passkey from JSON options
- `passkey.get()` - Authenticate with passkey
- `passkey.abort()` - Cancel in-flight create/get
- Internal abort handling for overlapping calls
- `passkeyCheck` in check namespace
- Console integration with mock options for testing
- `docs/passkey.md` documentation

## Breaking changes

None