### PR TITLE
chore(ci): fix rollup optional deps, migrate husky to v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install package dependencies
         run: |
           rm -rf node_modules package-lock.json
-          npm install
+          npm_config_platform=all npm install
 
       - name: Lint
         run: npm run lint

--- a/.husky/README.md
+++ b/.husky/README.md
@@ -53,3 +53,4 @@ Test linting:
 ```bash
 cd packages/pwafire && npm run lint
 ```
+# husky test

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Navigate to pwafire package
 cd packages/pwafire || exit 1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,6 @@ Quick reference for working on PWAFire. For detailed guidelines, see `/docs/*.md
 - [HTML/CSS Style](./docs/html-css-style.md) - Test console styling guidelines
 - [Tooling](./docs/tooling.md) - Prettier, ESLint, NPM scripts, testing requirements
 - [Console App](./docs/console.md) - Complete console app documentation
-- [Passkey API](./docs/passkey.md) - Passkey implementation notes and user verification
 
 ## Key Reminders
 


### PR DESCRIPTION
## Overview

Fixes CI failures and updates tooling for compatibility.

## Key changes

- **CI**: Use `npm_config_platform=all` to resolve Rollup optional dependencies on Linux runners
- **Husky**: Remove deprecated `husky.sh` lines for v10 compatibility
- **AGENTS.md**: Remove passkey doc link from quick links

## Breaking changes

None