### PR TITLE
docs(readme): add stackblitz live playground link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ const { ok, message } = await copyText("Hello World");
 
 ## Try it Live
 
-| Resource                                      | Description                       |
-| --------------------------------------------- | --------------------------------- |
-| [Launch Console](https://console.pwafire.org) | Test all PWA APIs in your browser |
+| Resource                                                                                    | Description                              |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| [Launch Console](https://console.pwafire.org)                                               | Test all PWA APIs in your browser        |
+| [StackBlitz Playground](https://stackblitz.com/edit/pwafire?file=src%2Findex.ts)            | Live demo and playground — edit and run  |
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Add [StackBlitz playground](https://stackblitz.com/edit/pwafire?file=src%2Findex.ts) to the "Try it Live" section in the README
- Anyone can now explore and run pwafire APIs directly in the browser without any local setup

## Test plan

- [ ] Verify the StackBlitz link opens correctly and the playground loads
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)