### PR TITLE
chore(pwafire): add repository, homepage, bugs, and author to package.json

### DIFF
--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -43,8 +43,17 @@
     "web",
     "app"
   ],
-  "author": "",
+  "author": "Maye Edwin",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pwafire/pwafire.git",
+    "directory": "packages/pwafire"
+  },
+  "homepage": "https://docs.pwafire.org",
+  "bugs": {
+    "url": "https://github.com/pwafire/pwafire/issues"
+  },
   "devDependencies": {
     "@types/dom-chromium-ai": "^0.0.14",
     "@types/jest": "^29.5.0",


### PR DESCRIPTION
## Summary
- Add `repository` field with GitHub URL and monorepo `directory` so npm displays the GitHub link
- Add `homepage` pointing to `https://docs.pwafire.org`
- Add `bugs` pointing to GitHub issues
- Set `author` to `Maye Edwin`

## Test plan
- [ ] Verify GitHub link appears on the npm package page after publish
- [ ] Verify homepage and bugs links appear on the npm package page after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)