### PR TITLE
docs(passkey): explain why result.credential needs serialization

### DIFF
--- a/docs/apis/passkey.md
+++ b/docs/apis/passkey.md
@@ -45,3 +45,22 @@ To cancel manually (e.g. when the user submits a form with a password instead of
 ```typescript
 form.addEventListener("submit", () => passkey.abort());
 ```
+
+## Serializing the credential for your backend
+
+`passkey.create()` and `passkey.get()` resolve with `result.credential` as the native [`PublicKeyCredential`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential) object. Its `rawId`, `clientDataJSON`, `attestationObject`, `authenticatorData`, `signature`, and `userHandle` fields are `ArrayBuffer`s, not strings — they don't survive a plain JSON post.
+
+Use the WebAuthn Level 3 [`toJSON()`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/toJSON) method to convert them to Base64URL-encoded strings before sending:
+
+```typescript
+const result = await pwafire.passkey.create(options);
+if (result.ok && result.credential) {
+  await fetch("/api/passkey/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(result.credential.toJSON()),
+  });
+}
+```
+
+`JSON.stringify` would invoke `toJSON()` implicitly, but calling it explicitly is clearer and lets you inspect or reshape the payload before sending. `toJSON()` is available in all modern browsers that support passkeys.


### PR DESCRIPTION
## Summary
- Document why `result.credential.toJSON()` is needed when posting a `PublicKeyCredential` to a backend (its `rawId`, `clientDataJSON`, `attestationObject`, `authenticatorData`, `signature`, `userHandle` are `ArrayBuffer`s and don't survive plain JSON).
- Add a `fetch` example calling `toJSON()` explicitly, and a note that `JSON.stringify` would invoke it implicitly but explicit is clearer.

## Test plan
- [ ] Render `docs/apis/passkey.md` and confirm the new "Serializing the credential for your backend" section displays correctly.
- [ ] Confirm the MDN links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)