### PR TITLE
feat(pwafire): v6.5.0 — typed error codes, capability subpath, size budgets

### DIFF
--- a/.github/workflows/pwafire-ci.yml
+++ b/.github/workflows/pwafire-ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build
         run: npm run -w pwafire build
 
+      - name: Size budget
+        run: npm run -w pwafire size
+
       - name: Coverage
         run: npm run -w pwafire test:coverage
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -26,7 +26,7 @@ const { ok, message } = await copyText("Bonjour le monde");
 ## Pourquoi pwafire
 
 - **Erreurs typées alignées sur la spec.** Chaque API renvoie `{ ok, message, code, cause }` où `code` est un littéral `ErrorCode` en kebab-case (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) — branchez dessus plutôt que de filtrer `message` par chaîne. L'erreur d'origine est conservée dans `cause`.
-- **Détection de capacité structurée.** `pwafire/capability` retourne `{ supported, reason, secureContext, requiresUserActivation, spec, mdn }` par API pour faire de l'enrichissement progressif avec des diagnostics actionnables. `pwafire/check` reste booléen pur.
+- **Détection de capacité structurée.** `pwafire/capability` retourne `{ supported, reason, secureContext, requiresUserActivation }` par API pour faire de l'enrichissement progressif avec des diagnostics actionnables. `pwafire/check` reste booléen pur.
 - **Tree-shakeable.** Imports profonds + `sideEffects: false` — vous payez uniquement ce que vous utilisez.
 - **Strictement rétro-compatible.** v6.5 est purement additif : chaque champ existant de chaque résultat est préservé. Les APIs qui exposaient déjà `status` (notification, summarizer, translator, language-detector) le conservent à côté du nouveau `code`, avec une note de suppression en v7.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,60 +23,6 @@ import { copyText } from "pwafire";
 const { ok, message } = await copyText("Bonjour le monde");
 ```
 
-## Pourquoi pwafire
-
-- **Erreurs typées alignées sur la spec.** Chaque API renvoie `{ ok, message, code, cause }` où `code` est un littéral `ErrorCode` en kebab-case (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) — branchez dessus plutôt que de filtrer `message` par chaîne. L'erreur d'origine est conservée dans `cause`.
-- **Détection de capacité structurée.** `pwafire/capability` retourne `{ supported, reason, secureContext, requiresUserActivation }` par API pour faire de l'enrichissement progressif avec des diagnostics actionnables. `pwafire/check` reste booléen pur.
-- **Tree-shakeable.** Imports profonds + `sideEffects: false` — vous payez uniquement ce que vous utilisez.
-- **Strictement rétro-compatible.** v6.5 est purement additif : chaque champ existant de chaque résultat est préservé. Les APIs qui exposaient déjà `status` (notification, summarizer, translator, language-detector) le conservent à côté du nouveau `code`, avec une note de suppression en v7.
-
-```ts
-import { copyText } from "pwafire/clipboard";
-import { clipboard } from "pwafire/capability";
-
-const cap = clipboard();
-if (!cap.supported) {
-  if (cap.reason === "insecure-context") return afficherBanniereHttps();
-  if (cap.reason === "no-user-activation") return activerSurClic();
-  return cacherBoutonCopier();
-}
-
-const r = await copyText("salut");
-if (!r.ok && r.code === "permission-denied") demanderAutorisation();
-```
-
-## Compatibilité navigateurs
-
-`ctx sécurisé` et `geste utilisateur` sont des exigences statiques de l'API. Les versions disponibles par navigateur vivent dans les liens — ils sont à jour au fil des releases.
-
-| API | ctx sécurisé | geste utilisateur | Référence |
-| --- | :-: | :-: | --- |
-| `badging` | ✅ | — | [Badging API](https://caniuse.com/mdn-api_navigator_setappbadge) |
-| `barcode` | — | — | [BarcodeDetector](https://caniuse.com/mdn-api_barcodedetector) |
-| `broadcast` | — | — | [BroadcastChannel](https://caniuse.com/broadcastchannel) |
-| `clipboard` | ✅ | ✅ | [Async Clipboard](https://caniuse.com/async-clipboard) |
-| `compression` | — | — | [CompressionStream](https://caniuse.com/mdn-api_compressionstream) |
-| `connectivity` | — | — | [navigator.onLine](https://caniuse.com/online-status) |
-| `contacts` | ✅ | ✅ | [Contact Picker](https://caniuse.com/mdn-api_contactsmanager) |
-| `content-indexing` | ✅ | — | [Content Index](https://caniuse.com/mdn-api_contentindex) |
-| `files` | ✅ | ✅ | [File System Access](https://caniuse.com/native-filesystem-api) |
-| `fonts` | ✅ | ✅ | [Local Font Access](https://caniuse.com/mdn-api_window_querylocalfonts) |
-| `fullscreen` | — | ✅ | [Fullscreen](https://caniuse.com/fullscreen) |
-| `idle-detection` | ✅ | ✅ | [IdleDetector](https://caniuse.com/mdn-api_idledetector) |
-| `install` | ✅ | ✅ | [web.dev install](https://web.dev/customize-install/) |
-| `language-detector` | ✅ | ✅ | [Chrome AI : Détection de langue](https://developer.chrome.com/docs/ai/language-detection) |
-| `lazy-load` | — | — | [loading=lazy](https://caniuse.com/loading-lazy-attr) |
-| `notification` | ✅ | ✅ | [Notifications](https://caniuse.com/notifications) |
-| `passkey` | ✅ | ✅ | [WebAuthn](https://caniuse.com/webauthn) |
-| `payment` | ✅ | ✅ | [Payment Request](https://caniuse.com/payment-request) |
-| `screen` | ✅ | ✅ | [getDisplayMedia](https://caniuse.com/mdn-api_mediadevices_getdisplaymedia) |
-| `summarizer` | ✅ | ✅ | [Chrome AI : Summarizer](https://developer.chrome.com/docs/ai/summarizer-api) |
-| `translator` | ✅ | ✅ | [Chrome AI : Translator](https://developer.chrome.com/docs/ai/translator-api) |
-| `visibility` | — | — | [Page Visibility](https://caniuse.com/pagevisibility) |
-| `wake-lock` | ✅ | — | [Screen Wake Lock](https://caniuse.com/wake-lock) |
-| `web-otp` | ✅ | ✅ | [Web OTP](https://caniuse.com/webotp) |
-| `web-share` | ✅ | ✅ | [Web Share](https://caniuse.com/web-share) |
-
 ## Tree-shaking
 
 Les imports nommés et profonds sont tree-shakés automatiquement par tout bundler moderne :

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,6 +23,60 @@ import { copyText } from "pwafire";
 const { ok, message } = await copyText("Bonjour le monde");
 ```
 
+## Pourquoi pwafire
+
+- **Erreurs typées alignées sur la spec.** Chaque API renvoie `{ ok, message, code, cause }` où `code` est un littéral `ErrorCode` en kebab-case (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) — branchez dessus plutôt que de filtrer `message` par chaîne. L'erreur d'origine est conservée dans `cause`.
+- **Détection de capacité structurée.** `pwafire/capability` retourne `{ supported, reason, secureContext, requiresUserActivation, spec, mdn }` par API pour faire de l'enrichissement progressif avec des diagnostics actionnables. `pwafire/check` reste booléen pur.
+- **Tree-shakeable.** Imports profonds + `sideEffects: false` — vous payez uniquement ce que vous utilisez.
+- **Strictement rétro-compatible.** v6.5 est purement additif : chaque champ existant de chaque résultat est préservé. Les APIs qui exposaient déjà `status` (notification, summarizer, translator, language-detector) le conservent à côté du nouveau `code`, avec une note de suppression en v7.
+
+```ts
+import { copyText } from "pwafire/clipboard";
+import { clipboard } from "pwafire/capability";
+
+const cap = clipboard();
+if (!cap.supported) {
+  if (cap.reason === "insecure-context") return afficherBanniereHttps();
+  if (cap.reason === "no-user-activation") return activerSurClic();
+  return cacherBoutonCopier();
+}
+
+const r = await copyText("salut");
+if (!r.ok && r.code === "permission-denied") demanderAutorisation();
+```
+
+## Compatibilité navigateurs
+
+`ctx sécurisé` et `geste utilisateur` sont des exigences statiques de l'API. Les versions disponibles par navigateur vivent dans les liens — ils sont à jour au fil des releases.
+
+| API | ctx sécurisé | geste utilisateur | Référence |
+| --- | :-: | :-: | --- |
+| `badging` | ✅ | — | [Badging API](https://caniuse.com/mdn-api_navigator_setappbadge) |
+| `barcode` | — | — | [BarcodeDetector](https://caniuse.com/mdn-api_barcodedetector) |
+| `broadcast` | — | — | [BroadcastChannel](https://caniuse.com/broadcastchannel) |
+| `clipboard` | ✅ | ✅ | [Async Clipboard](https://caniuse.com/async-clipboard) |
+| `compression` | — | — | [CompressionStream](https://caniuse.com/mdn-api_compressionstream) |
+| `connectivity` | — | — | [navigator.onLine](https://caniuse.com/online-status) |
+| `contacts` | ✅ | ✅ | [Contact Picker](https://caniuse.com/mdn-api_contactsmanager) |
+| `content-indexing` | ✅ | — | [Content Index](https://caniuse.com/mdn-api_contentindex) |
+| `files` | ✅ | ✅ | [File System Access](https://caniuse.com/native-filesystem-api) |
+| `fonts` | ✅ | ✅ | [Local Font Access](https://caniuse.com/mdn-api_window_querylocalfonts) |
+| `fullscreen` | — | ✅ | [Fullscreen](https://caniuse.com/fullscreen) |
+| `idle-detection` | ✅ | ✅ | [IdleDetector](https://caniuse.com/mdn-api_idledetector) |
+| `install` | ✅ | ✅ | [web.dev install](https://web.dev/customize-install/) |
+| `language-detector` | ✅ | ✅ | [Chrome AI : Détection de langue](https://developer.chrome.com/docs/ai/language-detection) |
+| `lazy-load` | — | — | [loading=lazy](https://caniuse.com/loading-lazy-attr) |
+| `notification` | ✅ | ✅ | [Notifications](https://caniuse.com/notifications) |
+| `passkey` | ✅ | ✅ | [WebAuthn](https://caniuse.com/webauthn) |
+| `payment` | ✅ | ✅ | [Payment Request](https://caniuse.com/payment-request) |
+| `screen` | ✅ | ✅ | [getDisplayMedia](https://caniuse.com/mdn-api_mediadevices_getdisplaymedia) |
+| `summarizer` | ✅ | ✅ | [Chrome AI : Summarizer](https://developer.chrome.com/docs/ai/summarizer-api) |
+| `translator` | ✅ | ✅ | [Chrome AI : Translator](https://developer.chrome.com/docs/ai/translator-api) |
+| `visibility` | — | — | [Page Visibility](https://caniuse.com/pagevisibility) |
+| `wake-lock` | ✅ | — | [Screen Wake Lock](https://caniuse.com/wake-lock) |
+| `web-otp` | ✅ | ✅ | [Web OTP](https://caniuse.com/webotp) |
+| `web-share` | ✅ | ✅ | [Web Share](https://caniuse.com/web-share) |
+
 ## Tree-shaking
 
 Les imports nommés et profonds sont tree-shakés automatiquement par tout bundler moderne :

--- a/README.md
+++ b/README.md
@@ -23,60 +23,6 @@ import { copyText } from "pwafire";
 const { ok, message } = await copyText("Hello World");
 ```
 
-## Why pwafire
-
-- **Spec-aligned typed errors.** Every API returns `{ ok, message, code, cause }` where `code` is a kebab-case `ErrorCode` literal (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) — branch on it instead of string-matching `message`. The original error is preserved on `cause`.
-- **Structured capability detection.** `pwafire/capability` reports `{ supported, reason, secureContext, requiresUserActivation }` per API so you can progressively enhance with actionable diagnostics. `pwafire/check` stays boolean-only.
-- **Tree-shakeable.** Deep imports + `sideEffects: false` — pay only for what you use.
-- **Strictly back-compat.** v6.5 is additive: every existing field on every result is preserved. APIs that already exposed `status` (notification, summarizer, translator, language-detector) keep it alongside the new `code`, with a v7 removal note.
-
-```ts
-import { copyText } from "pwafire/clipboard";
-import { clipboard } from "pwafire/capability";
-
-const cap = clipboard();
-if (!cap.supported) {
-  if (cap.reason === "insecure-context") return showUpgradeToHttpsBanner();
-  if (cap.reason === "no-user-activation") return enableOnNextClick();
-  return hideCopyButton();
-}
-
-const r = await copyText("hi");
-if (!r.ok && r.code === "permission-denied") promptUserToAllow();
-```
-
-## Browser support
-
-`secure ctx` and `user gesture` are static API requirements. Browser version availability lives in the linked references — they update as engines ship.
-
-| API | secure ctx | user gesture | Reference |
-| --- | :-: | :-: | --- |
-| `badging` | ✅ | — | [Badging API](https://caniuse.com/mdn-api_navigator_setappbadge) |
-| `barcode` | — | — | [BarcodeDetector](https://caniuse.com/mdn-api_barcodedetector) |
-| `broadcast` | — | — | [BroadcastChannel](https://caniuse.com/broadcastchannel) |
-| `clipboard` | ✅ | ✅ | [Async Clipboard](https://caniuse.com/async-clipboard) |
-| `compression` | — | — | [CompressionStream](https://caniuse.com/mdn-api_compressionstream) |
-| `connectivity` | — | — | [navigator.onLine](https://caniuse.com/online-status) |
-| `contacts` | ✅ | ✅ | [Contact Picker](https://caniuse.com/mdn-api_contactsmanager) |
-| `content-indexing` | ✅ | — | [Content Index](https://caniuse.com/mdn-api_contentindex) |
-| `files` | ✅ | ✅ | [File System Access](https://caniuse.com/native-filesystem-api) |
-| `fonts` | ✅ | ✅ | [Local Font Access](https://caniuse.com/mdn-api_window_querylocalfonts) |
-| `fullscreen` | — | ✅ | [Fullscreen](https://caniuse.com/fullscreen) |
-| `idle-detection` | ✅ | ✅ | [IdleDetector](https://caniuse.com/mdn-api_idledetector) |
-| `install` | ✅ | ✅ | [web.dev install](https://web.dev/customize-install/) |
-| `language-detector` | ✅ | ✅ | [Chrome AI: Language Detection](https://developer.chrome.com/docs/ai/language-detection) |
-| `lazy-load` | — | — | [loading=lazy](https://caniuse.com/loading-lazy-attr) |
-| `notification` | ✅ | ✅ | [Notifications](https://caniuse.com/notifications) |
-| `passkey` | ✅ | ✅ | [WebAuthn](https://caniuse.com/webauthn) |
-| `payment` | ✅ | ✅ | [Payment Request](https://caniuse.com/payment-request) |
-| `screen` | ✅ | ✅ | [getDisplayMedia](https://caniuse.com/mdn-api_mediadevices_getdisplaymedia) |
-| `summarizer` | ✅ | ✅ | [Chrome AI: Summarizer](https://developer.chrome.com/docs/ai/summarizer-api) |
-| `translator` | ✅ | ✅ | [Chrome AI: Translator](https://developer.chrome.com/docs/ai/translator-api) |
-| `visibility` | — | — | [Page Visibility](https://caniuse.com/pagevisibility) |
-| `wake-lock` | ✅ | — | [Screen Wake Lock](https://caniuse.com/wake-lock) |
-| `web-otp` | ✅ | ✅ | [Web OTP](https://caniuse.com/webotp) |
-| `web-share` | ✅ | ✅ | [Web Share](https://caniuse.com/web-share) |
-
 ## Tree-shaking
 
 Named and deep imports tree-shake automatically with any modern bundler:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,60 @@ import { copyText } from "pwafire";
 const { ok, message } = await copyText("Hello World");
 ```
 
+## Why pwafire
+
+- **Spec-aligned typed errors.** Every API returns `{ ok, message, code, cause }` where `code` is a kebab-case `ErrorCode` literal (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) — branch on it instead of string-matching `message`. The original error is preserved on `cause`.
+- **Structured capability detection.** `pwafire/capability` reports `{ supported, reason, secureContext, requiresUserActivation, spec, mdn }` per API so you can progressively enhance with actionable diagnostics. `pwafire/check` stays boolean-only.
+- **Tree-shakeable.** Deep imports + `sideEffects: false` — pay only for what you use.
+- **Strictly back-compat.** v6.5 is additive: every existing field on every result is preserved. APIs that already exposed `status` (notification, summarizer, translator, language-detector) keep it alongside the new `code`, with a v7 removal note.
+
+```ts
+import { copyText } from "pwafire/clipboard";
+import { clipboard } from "pwafire/capability";
+
+const cap = clipboard();
+if (!cap.supported) {
+  if (cap.reason === "insecure-context") return showUpgradeToHttpsBanner();
+  if (cap.reason === "no-user-activation") return enableOnNextClick();
+  return hideCopyButton();
+}
+
+const r = await copyText("hi");
+if (!r.ok && r.code === "permission-denied") promptUserToAllow();
+```
+
+## Browser support
+
+`secure ctx` and `user gesture` are static API requirements. Browser version availability lives in the linked references — they update as engines ship.
+
+| API | secure ctx | user gesture | Reference |
+| --- | :-: | :-: | --- |
+| `badging` | ✅ | — | [Badging API](https://caniuse.com/mdn-api_navigator_setappbadge) |
+| `barcode` | — | — | [BarcodeDetector](https://caniuse.com/mdn-api_barcodedetector) |
+| `broadcast` | — | — | [BroadcastChannel](https://caniuse.com/broadcastchannel) |
+| `clipboard` | ✅ | ✅ | [Async Clipboard](https://caniuse.com/async-clipboard) |
+| `compression` | — | — | [CompressionStream](https://caniuse.com/mdn-api_compressionstream) |
+| `connectivity` | — | — | [navigator.onLine](https://caniuse.com/online-status) |
+| `contacts` | ✅ | ✅ | [Contact Picker](https://caniuse.com/mdn-api_contactsmanager) |
+| `content-indexing` | ✅ | — | [Content Index](https://caniuse.com/mdn-api_contentindex) |
+| `files` | ✅ | ✅ | [File System Access](https://caniuse.com/native-filesystem-api) |
+| `fonts` | ✅ | ✅ | [Local Font Access](https://caniuse.com/mdn-api_window_querylocalfonts) |
+| `fullscreen` | — | ✅ | [Fullscreen](https://caniuse.com/fullscreen) |
+| `idle-detection` | ✅ | ✅ | [IdleDetector](https://caniuse.com/mdn-api_idledetector) |
+| `install` | ✅ | ✅ | [web.dev install](https://web.dev/customize-install/) |
+| `language-detector` | ✅ | ✅ | [Chrome AI: Language Detection](https://developer.chrome.com/docs/ai/language-detection) |
+| `lazy-load` | — | — | [loading=lazy](https://caniuse.com/loading-lazy-attr) |
+| `notification` | ✅ | ✅ | [Notifications](https://caniuse.com/notifications) |
+| `passkey` | ✅ | ✅ | [WebAuthn](https://caniuse.com/webauthn) |
+| `payment` | ✅ | ✅ | [Payment Request](https://caniuse.com/payment-request) |
+| `screen` | ✅ | ✅ | [getDisplayMedia](https://caniuse.com/mdn-api_mediadevices_getdisplaymedia) |
+| `summarizer` | ✅ | ✅ | [Chrome AI: Summarizer](https://developer.chrome.com/docs/ai/summarizer-api) |
+| `translator` | ✅ | ✅ | [Chrome AI: Translator](https://developer.chrome.com/docs/ai/translator-api) |
+| `visibility` | — | — | [Page Visibility](https://caniuse.com/pagevisibility) |
+| `wake-lock` | ✅ | — | [Screen Wake Lock](https://caniuse.com/wake-lock) |
+| `web-otp` | ✅ | ✅ | [Web OTP](https://caniuse.com/webotp) |
+| `web-share` | ✅ | ✅ | [Web Share](https://caniuse.com/web-share) |
+
 ## Tree-shaking
 
 Named and deep imports tree-shake automatically with any modern bundler:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const { ok, message } = await copyText("Hello World");
 ## Why pwafire
 
 - **Spec-aligned typed errors.** Every API returns `{ ok, message, code, cause }` where `code` is a kebab-case `ErrorCode` literal (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) — branch on it instead of string-matching `message`. The original error is preserved on `cause`.
-- **Structured capability detection.** `pwafire/capability` reports `{ supported, reason, secureContext, requiresUserActivation, spec, mdn }` per API so you can progressively enhance with actionable diagnostics. `pwafire/check` stays boolean-only.
+- **Structured capability detection.** `pwafire/capability` reports `{ supported, reason, secureContext, requiresUserActivation }` per API so you can progressively enhance with actionable diagnostics. `pwafire/check` stays boolean-only.
 - **Tree-shakeable.** Deep imports + `sideEffects: false` — pay only for what you use.
 - **Strictly back-compat.** v6.5 is additive: every existing field on every result is preserved. APIs that already exposed `status` (notification, summarizer, translator, language-detector) keep it alongside the new `code`, with a v7 removal note.
 

--- a/console/index.html
+++ b/console/index.html
@@ -122,6 +122,12 @@
           <div id="imports-list"></div>
         </div>
 
+        <div class="stats-panel">
+          <div class="stats-title">v6.5 Capability</div>
+          <div id="capability-demo-list"></div>
+          <button onclick="window.demoCopy().then(m => window.logConsole(m, 'info'))" style="margin-top: 8px; width: 100%;">Try copyText (typed code)</button>
+        </div>
+
         <div class="shortcuts-panel">
           <div class="shortcuts-title">Shortcuts</div>
           <div><code>Ctrl+R</code> Run All</div>

--- a/console/src/app/index.ts
+++ b/console/src/app/index.ts
@@ -9,6 +9,7 @@ import { generateTests, runTest, runAllTests } from "../tests";
 import { checkAllFeatures } from "../features";
 import { initKeyboardShortcuts } from "../keyboard";
 import { renderImportsPanel, importsSummary } from "../imports";
+import { renderCapabilityDemo, capabilityDemoSummary, demoCopy } from "../capability-demo";
 
 declare global {
   interface Window {
@@ -23,6 +24,8 @@ declare global {
     downloadStream: typeof downloadStream;
     showTopLoadingBar: () => void;
     hideTopLoadingBar: () => void;
+    demoCopy: typeof demoCopy;
+    logConsole: typeof logConsole;
     __visibilityUnlisten: (() => void) | null;
   }
 }
@@ -61,6 +64,8 @@ export const init = (): void => {
   window.downloadStream = downloadStream;
   window.showTopLoadingBar = showTopLoadingBar;
   window.hideTopLoadingBar = hideTopLoadingBar;
+  window.demoCopy = demoCopy;
+  window.logConsole = logConsole;
 
   logConsole("PWAFire package loaded successfully", "success");
   logConsole("Available exports: " + Object.keys(pwafire).length, "info");
@@ -79,6 +84,13 @@ export const init = (): void => {
   logConsole(
     `Import shapes verified: ${imports.ok}/${imports.total}`,
     imports.ok === imports.total ? "success" : "error"
+  );
+
+  renderCapabilityDemo();
+  const capability = capabilityDemoSummary();
+  logConsole(
+    `Capability detection live: ${capability.supported}/${capability.total} supported in this browser`,
+    "info"
   );
 
   // Hide loading screen and show content after 2s delay

--- a/console/src/capability-demo/index.ts
+++ b/console/src/capability-demo/index.ts
@@ -1,28 +1,32 @@
 // Exercises the v6.5 surface end-to-end in a real consumer:
-// - `pwafire/capability` for structured detection (one row per API,
-//   showing supported/reason live)
+// - `pwafire/capability` for structured detection — re-evaluated per
+//   render so `userActivation`/`secureContext`/etc. reflect live state
 // - typed `code` discriminator from `pwafire/clipboard` on the copy
 //   button (branches on the literal, not the message)
 
 import { copyText } from "pwafire";
 import * as cap from "pwafire/capability";
 
-type Row = { label: string; cap: ReturnType<typeof cap.clipboard> };
-
-const rows: Row[] = [
-  { label: "clipboard", cap: cap.clipboard() },
-  { label: "notification", cap: cap.notification() },
-  { label: "passkey", cap: cap.passkey() },
-  { label: "web-share", cap: cap.webShare() },
-  { label: "wake-lock", cap: cap.wakeLock() },
+const LABELS: Array<{ label: string; probe: () => ReturnType<typeof cap.clipboard> }> = [
+  { label: "clipboard", probe: cap.clipboard },
+  { label: "notification", probe: cap.notification },
+  { label: "passkey", probe: cap.passkey },
+  { label: "web-share", probe: cap.webShare },
+  { label: "wake-lock", probe: cap.wakeLock },
 ];
+
+// Read live each render — capability is `userActivation.isActive`-sensitive
+// (and `isSecureContext`-sensitive), so a one-shot read at module load
+// would freeze `reason` at "no-user-activation" forever after the first
+// user click.
+const snapshot = () => LABELS.map(({ label, probe }) => ({ label, c: probe() }));
 
 export const renderCapabilityDemo = (mountId = "capability-demo-list"): void => {
   const mount = document.getElementById(mountId);
   if (!mount) return;
 
-  mount.innerHTML = rows
-    .map(({ label, cap: c }) => {
+  mount.innerHTML = snapshot()
+    .map(({ label, c }) => {
       const ok = c.supported ? "ok" : "fail";
       const status = c.supported ? "supported" : c.reason ?? "no-api";
       return `
@@ -36,15 +40,21 @@ export const renderCapabilityDemo = (mountId = "capability-demo-list"): void => 
     .join("");
 };
 
-export const capabilityDemoSummary = (): { supported: number; total: number } => ({
-  supported: rows.filter((r) => r.cap.supported).length,
-  total: rows.length,
-});
+export const capabilityDemoSummary = (): { supported: number; total: number } => {
+  const live = snapshot();
+  return {
+    supported: live.filter((r) => r.c.supported).length,
+    total: live.length,
+  };
+};
 
 // Wired to the in-app "Try copyText" button (see console/index.html).
 // Demonstrates the typed-code branching pattern consumers should adopt.
+// After clicking, re-renders the panel so the reason flips from
+// "no-user-activation" → "supported" (proving the live re-read works).
 export const demoCopy = async (): Promise<string> => {
   const r = await copyText("hello from pwafire v6.5");
+  renderCapabilityDemo();
   if (r.ok) return "copied to clipboard";
   switch (r.code) {
     case "permission-denied":

--- a/console/src/capability-demo/index.ts
+++ b/console/src/capability-demo/index.ts
@@ -1,0 +1,59 @@
+// Exercises the v6.5 surface end-to-end in a real consumer:
+// - `pwafire/capability` for structured detection (one row per API,
+//   showing supported/reason live)
+// - typed `code` discriminator from `pwafire/clipboard` on the copy
+//   button (branches on the literal, not the message)
+
+import { copyText } from "pwafire";
+import * as cap from "pwafire/capability";
+
+type Row = { label: string; cap: ReturnType<typeof cap.clipboard> };
+
+const rows: Row[] = [
+  { label: "clipboard", cap: cap.clipboard() },
+  { label: "notification", cap: cap.notification() },
+  { label: "passkey", cap: cap.passkey() },
+  { label: "web-share", cap: cap.webShare() },
+  { label: "wake-lock", cap: cap.wakeLock() },
+];
+
+export const renderCapabilityDemo = (mountId = "capability-demo-list"): void => {
+  const mount = document.getElementById(mountId);
+  if (!mount) return;
+
+  mount.innerHTML = rows
+    .map(({ label, cap: c }) => {
+      const ok = c.supported ? "ok" : "fail";
+      const status = c.supported ? "supported" : c.reason ?? "no-api";
+      return `
+        <div class="import-row ${ok}" title="secureContext=${c.secureContext}; needsGesture=${c.requiresUserActivation}">
+          <span class="import-status">${c.supported ? "✓" : "✗"}</span>
+          <span class="import-label">${label}</span>
+          <span class="import-reason">${status}</span>
+        </div>
+      `;
+    })
+    .join("");
+};
+
+export const capabilityDemoSummary = (): { supported: number; total: number } => ({
+  supported: rows.filter((r) => r.cap.supported).length,
+  total: rows.length,
+});
+
+// Wired to the in-app "Try copyText" button (see console/index.html).
+// Demonstrates the typed-code branching pattern consumers should adopt.
+export const demoCopy = async (): Promise<string> => {
+  const r = await copyText("hello from pwafire v6.5");
+  if (r.ok) return "copied to clipboard";
+  switch (r.code) {
+    case "permission-denied":
+      return "permission denied — grant clipboard access and retry";
+    case "unsupported":
+      return "Clipboard API not supported in this browser";
+    case "gesture-required":
+      return "needs a user gesture — click again";
+    default:
+      return `failed: ${r.code ?? "unknown"} (${r.message})`;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8770,7 +8770,7 @@
       }
     },
     "packages/pwafire": {
-      "version": "6.4.4",
+      "version": "6.5.0",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^12.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,6 +2675,535 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@size-limit/esbuild": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-12.1.0.tgz",
+      "integrity": "sha512-Um6MVrX+05kIxI4+zk0ZByG9dA/Th1f+sfGc571D95BnCPc90/pl2+2OdsQuOyoWEbeAMqfcTKo0v07i+E65Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.28.0",
+        "nanoid": "^5.1.7"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@size-limit/esbuild/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
+    "node_modules/@size-limit/preset-small-lib": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-12.1.0.tgz",
+      "integrity": "sha512-TVVQ/iuHbaGtHJrjur5s4XKYEyGk0nIwUAqhuzhKPbTyV9nYOH/laDelQ4vg3cGmm8sayRx998wxEdnwM/Yewg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@size-limit/esbuild": "12.1.0",
+        "@size-limit/file": "12.1.0",
+        "size-limit": "12.1.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3468,6 +3997,16 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -6411,6 +6950,35 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7216,6 +7784,34 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -8177,6 +8773,7 @@
       "version": "6.4.4",
       "license": "MIT",
       "devDependencies": {
+        "@size-limit/preset-small-lib": "^12.1.0",
         "@types/dom-chromium-ai": "^0.0.14",
         "@types/jest": "^29.5.0",
         "@types/node": "^18.15.11",
@@ -8186,6 +8783,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^30.2.0",
         "prettier": "^2.8.4",
+        "size-limit": "^12.1.0",
         "ts-jest": "^29.1.0",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3"

--- a/packages/pwafire/.size-limit.json
+++ b/packages/pwafire/.size-limit.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "pwafire (full surface)",
+    "path": "lib/index.mjs",
+    "limit": "10 kB",
+    "import": "*"
+  },
+  {
+    "name": "pwafire/check",
+    "path": "lib/check/index.mjs",
+    "limit": "700 B",
+    "import": "*"
+  },
+  {
+    "name": "pwafire/capability",
+    "path": "lib/capability/index.mjs",
+    "limit": "2.2 kB",
+    "import": "*"
+  },
+  {
+    "name": "pwafire/clipboard",
+    "path": "lib/pwa/clipboard/index.mjs",
+    "limit": "600 B",
+    "import": "*"
+  },
+  {
+    "name": "pwafire/notification",
+    "path": "lib/pwa/notification/index.mjs",
+    "limit": "500 B",
+    "import": "*"
+  },
+  {
+    "name": "pwafire/passkey",
+    "path": "lib/pwa/passkey/index.mjs",
+    "limit": "1 kB",
+    "import": "*"
+  }
+]

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwafire",
-  "version": "6.4.4",
+  "version": "6.5.0",
   "description": "A collection of PWA APIs and utilities",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
@@ -195,7 +195,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "sync:exports": "node scripts/sync-exports.mjs",
     "sync:exports:check": "node scripts/sync-exports.mjs --check",
-    "verify": "npm run sync:exports:check && npm run lint && npm run build && npm test",
+    "size": "size-limit",
+    "verify": "npm run sync:exports:check && npm run lint && npm run build && npm test && npm run size",
     "prepublishOnly": "npm run verify"
   },
   "keywords": [
@@ -221,6 +222,7 @@
     "url": "https://github.com/pwafire/pwafire/issues"
   },
   "devDependencies": {
+    "@size-limit/preset-small-lib": "^12.1.0",
     "@types/dom-chromium-ai": "^0.0.14",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
@@ -230,6 +232,7 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^30.2.0",
     "prettier": "^2.8.4",
+    "size-limit": "^12.1.0",
     "ts-jest": "^29.1.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"

--- a/packages/pwafire/package.json
+++ b/packages/pwafire/package.json
@@ -9,142 +9,176 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
+      "browser": "./lib/index.mjs",
       "import": "./lib/index.mjs",
       "require": "./lib/index.js"
     },
     "./check": {
       "types": "./lib/check/index.d.ts",
+      "browser": "./lib/check/index.mjs",
       "import": "./lib/check/index.mjs",
       "require": "./lib/check/index.js"
     },
+    "./capability": {
+      "types": "./lib/capability/index.d.ts",
+      "browser": "./lib/capability/index.mjs",
+      "import": "./lib/capability/index.mjs",
+      "require": "./lib/capability/index.js"
+    },
     "./badging": {
       "types": "./lib/pwa/badging/index.d.ts",
+      "browser": "./lib/pwa/badging/index.mjs",
       "import": "./lib/pwa/badging/index.mjs",
       "require": "./lib/pwa/badging/index.js"
     },
     "./barcode": {
       "types": "./lib/pwa/barcode/index.d.ts",
+      "browser": "./lib/pwa/barcode/index.mjs",
       "import": "./lib/pwa/barcode/index.mjs",
       "require": "./lib/pwa/barcode/index.js"
     },
     "./broadcast": {
       "types": "./lib/pwa/broadcast/index.d.ts",
+      "browser": "./lib/pwa/broadcast/index.mjs",
       "import": "./lib/pwa/broadcast/index.mjs",
       "require": "./lib/pwa/broadcast/index.js"
     },
     "./clipboard": {
       "types": "./lib/pwa/clipboard/index.d.ts",
+      "browser": "./lib/pwa/clipboard/index.mjs",
       "import": "./lib/pwa/clipboard/index.mjs",
       "require": "./lib/pwa/clipboard/index.js"
     },
     "./compression": {
       "types": "./lib/pwa/compression/index.d.ts",
+      "browser": "./lib/pwa/compression/index.mjs",
       "import": "./lib/pwa/compression/index.mjs",
       "require": "./lib/pwa/compression/index.js"
     },
     "./connectivity": {
       "types": "./lib/pwa/connectivity/index.d.ts",
+      "browser": "./lib/pwa/connectivity/index.mjs",
       "import": "./lib/pwa/connectivity/index.mjs",
       "require": "./lib/pwa/connectivity/index.js"
     },
     "./contacts": {
       "types": "./lib/pwa/contacts/index.d.ts",
+      "browser": "./lib/pwa/contacts/index.mjs",
       "import": "./lib/pwa/contacts/index.mjs",
       "require": "./lib/pwa/contacts/index.js"
     },
     "./content-indexing": {
       "types": "./lib/pwa/content-indexing/index.d.ts",
+      "browser": "./lib/pwa/content-indexing/index.mjs",
       "import": "./lib/pwa/content-indexing/index.mjs",
       "require": "./lib/pwa/content-indexing/index.js"
     },
     "./files": {
       "types": "./lib/pwa/files/index.d.ts",
+      "browser": "./lib/pwa/files/index.mjs",
       "import": "./lib/pwa/files/index.mjs",
       "require": "./lib/pwa/files/index.js"
     },
     "./fonts": {
       "types": "./lib/pwa/fonts/index.d.ts",
+      "browser": "./lib/pwa/fonts/index.mjs",
       "import": "./lib/pwa/fonts/index.mjs",
       "require": "./lib/pwa/fonts/index.js"
     },
     "./fullscreen": {
       "types": "./lib/pwa/fullscreen/index.d.ts",
+      "browser": "./lib/pwa/fullscreen/index.mjs",
       "import": "./lib/pwa/fullscreen/index.mjs",
       "require": "./lib/pwa/fullscreen/index.js"
     },
     "./idle-detection": {
       "types": "./lib/pwa/idle-detection/index.d.ts",
+      "browser": "./lib/pwa/idle-detection/index.mjs",
       "import": "./lib/pwa/idle-detection/index.mjs",
       "require": "./lib/pwa/idle-detection/index.js"
     },
     "./install": {
       "types": "./lib/pwa/install/index.d.ts",
+      "browser": "./lib/pwa/install/index.mjs",
       "import": "./lib/pwa/install/index.mjs",
       "require": "./lib/pwa/install/index.js"
     },
     "./language-detector": {
       "types": "./lib/pwa/language-detector/index.d.ts",
+      "browser": "./lib/pwa/language-detector/index.mjs",
       "import": "./lib/pwa/language-detector/index.mjs",
       "require": "./lib/pwa/language-detector/index.js"
     },
     "./lazy-load": {
       "types": "./lib/pwa/lazy-load/index.d.ts",
+      "browser": "./lib/pwa/lazy-load/index.mjs",
       "import": "./lib/pwa/lazy-load/index.mjs",
       "require": "./lib/pwa/lazy-load/index.js"
     },
     "./notification": {
       "types": "./lib/pwa/notification/index.d.ts",
+      "browser": "./lib/pwa/notification/index.mjs",
       "import": "./lib/pwa/notification/index.mjs",
       "require": "./lib/pwa/notification/index.js"
     },
     "./passkey": {
       "types": "./lib/pwa/passkey/index.d.ts",
+      "browser": "./lib/pwa/passkey/index.mjs",
       "import": "./lib/pwa/passkey/index.mjs",
       "require": "./lib/pwa/passkey/index.js"
     },
     "./payment": {
       "types": "./lib/pwa/payment/index.d.ts",
+      "browser": "./lib/pwa/payment/index.mjs",
       "import": "./lib/pwa/payment/index.mjs",
       "require": "./lib/pwa/payment/index.js"
     },
     "./screen": {
       "types": "./lib/pwa/screen/index.d.ts",
+      "browser": "./lib/pwa/screen/index.mjs",
       "import": "./lib/pwa/screen/index.mjs",
       "require": "./lib/pwa/screen/index.js"
     },
     "./summarizer": {
       "types": "./lib/pwa/summarizer/index.d.ts",
+      "browser": "./lib/pwa/summarizer/index.mjs",
       "import": "./lib/pwa/summarizer/index.mjs",
       "require": "./lib/pwa/summarizer/index.js"
     },
     "./translator": {
       "types": "./lib/pwa/translator/index.d.ts",
+      "browser": "./lib/pwa/translator/index.mjs",
       "import": "./lib/pwa/translator/index.mjs",
       "require": "./lib/pwa/translator/index.js"
     },
     "./visibility": {
       "types": "./lib/pwa/visibility/index.d.ts",
+      "browser": "./lib/pwa/visibility/index.mjs",
       "import": "./lib/pwa/visibility/index.mjs",
       "require": "./lib/pwa/visibility/index.js"
     },
     "./wake-lock": {
       "types": "./lib/pwa/wake-lock/index.d.ts",
+      "browser": "./lib/pwa/wake-lock/index.mjs",
       "import": "./lib/pwa/wake-lock/index.mjs",
       "require": "./lib/pwa/wake-lock/index.js"
     },
     "./web-otp": {
       "types": "./lib/pwa/web-otp/index.d.ts",
+      "browser": "./lib/pwa/web-otp/index.mjs",
       "import": "./lib/pwa/web-otp/index.mjs",
       "require": "./lib/pwa/web-otp/index.js"
     },
     "./web-share": {
       "types": "./lib/pwa/web-share/index.d.ts",
+      "browser": "./lib/pwa/web-share/index.mjs",
       "import": "./lib/pwa/web-share/index.mjs",
       "require": "./lib/pwa/web-share/index.js"
     },
     "./package.json": "./package.json",
     "./*": {
       "types": "./lib/pwa/*/index.d.ts",
+      "browser": "./lib/pwa/*/index.mjs",
       "import": "./lib/pwa/*/index.mjs",
       "require": "./lib/pwa/*/index.js"
     }
@@ -153,8 +187,8 @@
     "lib"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/pwa/**/index.ts src/check/index.ts --format cjs,esm --dts --out-dir lib --treeshake --no-splitting",
-    "dev": "tsup src/index.ts src/pwa/**/index.ts src/check/index.ts --format cjs,esm --dts --out-dir lib --watch --treeshake --no-splitting",
+    "build": "tsup src/index.ts src/pwa/**/index.ts src/check/index.ts src/capability/index.ts --format cjs,esm --dts --out-dir lib --treeshake --no-splitting",
+    "dev": "tsup src/index.ts src/pwa/**/index.ts src/check/index.ts src/capability/index.ts --format cjs,esm --dts --out-dir lib --watch --treeshake --no-splitting",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",

--- a/packages/pwafire/scripts/sync-exports.mjs
+++ b/packages/pwafire/scripts/sync-exports.mjs
@@ -19,26 +19,36 @@ const apis = readdirSync(pwaDir)
   })
   .sort();
 
+// `browser` is listed before `import` so bundler/runtime resolvers that
+// honor it (Vite, esbuild via tsup --platform=browser, Webpack) pick the
+// browser build for SSR-aware consumers.
 const apiEntry = (subpath) => ({
   types: `./lib/${subpath}/index.d.ts`,
+  browser: `./lib/${subpath}/index.mjs`,
   import: `./lib/${subpath}/index.mjs`,
   require: `./lib/${subpath}/index.js`,
 });
 
 const exportsMap = {
-  ".": {
-    types: "./lib/index.d.ts",
-    import: "./lib/index.mjs",
-    require: "./lib/index.js",
-  },
+  ".": apiEntry(""),
   "./check": apiEntry("check"),
+  "./capability": apiEntry("capability"),
   ...Object.fromEntries(apis.map((name) => [`./${name}`, apiEntry(`pwa/${name}`)])),
   "./package.json": "./package.json",
   "./*": {
     types: "./lib/pwa/*/index.d.ts",
+    browser: "./lib/pwa/*/index.mjs",
     import: "./lib/pwa/*/index.mjs",
     require: "./lib/pwa/*/index.js",
   },
+};
+
+// Root entry uses lib/index.* (no /pwa prefix); fix up after the helper.
+exportsMap["."] = {
+  types: "./lib/index.d.ts",
+  browser: "./lib/index.mjs",
+  import: "./lib/index.mjs",
+  require: "./lib/index.js",
 };
 
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
@@ -52,8 +62,8 @@ if (check) {
     console.error("✗ package.json exports out of sync with src/pwa/. Run: npm run -w pwafire sync:exports");
     process.exit(1);
   }
-  console.log(`✓ exports in sync (${apis.length} APIs)`);
+  console.log(`✓ exports in sync (${apis.length} APIs + check + capability)`);
 } else {
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf8");
-  console.log(`✓ wrote ${apis.length} API exports + ./check, ./package.json, ./*`);
+  console.log(`✓ wrote ${apis.length} API exports + ./check, ./capability, ./package.json, ./*`);
 }

--- a/packages/pwafire/src/capability/index.ts
+++ b/packages/pwafire/src/capability/index.ts
@@ -1,5 +1,8 @@
 import type { Capability, CapabilityReason } from "../types/capability";
 
+// Single SSR / non-browser safety net. Probes can freely reference
+// window/navigator/self/document without per-probe `typeof` guards —
+// missing globals throw ReferenceError, which we catch here.
 const apiExists = (probe: () => boolean): boolean => {
   try {
     return probe();
@@ -45,7 +48,7 @@ export const compression = (): Capability =>
   make(() => "CompressionStream" in window, { requiresUserActivation: false });
 
 export const connectivity = (): Capability =>
-  make(() => typeof navigator !== "undefined" && "onLine" in navigator, { requiresUserActivation: false });
+  make(() => "onLine" in navigator, { requiresUserActivation: false });
 
 export const contacts = (): Capability =>
   make(() => "contacts" in navigator && "ContactsManager" in window, {
@@ -63,9 +66,7 @@ export const fonts = (): Capability =>
   make(() => "queryLocalFonts" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const fullscreen = (): Capability =>
-  make(() => typeof document !== "undefined" && document.fullscreenEnabled === true, {
-    requiresUserActivation: true,
-  });
+  make(() => document.fullscreenEnabled === true, { requiresUserActivation: true });
 
 export const idleDetection = (): Capability =>
   make(() => "IdleDetector" in window, { requiresUserActivation: true, requiresSecureContext: true });
@@ -81,9 +82,7 @@ export const languageDetector = (): Capability =>
   make(() => "LanguageDetector" in self, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const lazyLoad = (): Capability =>
-  make(() => typeof HTMLImageElement !== "undefined" && "loading" in HTMLImageElement.prototype, {
-    requiresUserActivation: false,
-  });
+  make(() => "loading" in HTMLImageElement.prototype, { requiresUserActivation: false });
 
 export const notification = (): Capability =>
   make(() => "Notification" in window, { requiresUserActivation: true, requiresSecureContext: true });
@@ -95,7 +94,7 @@ export const passkey = (): Capability =>
   });
 
 export const payment = (): Capability =>
-  make(() => typeof window !== "undefined" && typeof window.PaymentRequest !== "undefined", {
+  make(() => typeof window.PaymentRequest !== "undefined", {
     requiresUserActivation: true,
     requiresSecureContext: true,
   });
@@ -104,13 +103,10 @@ export const pip = (): Capability =>
   make(() => "documentPictureInPicture" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const screenShare = (): Capability =>
-  make(
-    () =>
-      typeof navigator !== "undefined" &&
-      !!navigator.mediaDevices &&
-      "getDisplayMedia" in navigator.mediaDevices,
-    { requiresUserActivation: true, requiresSecureContext: true },
-  );
+  make(() => !!navigator.mediaDevices && "getDisplayMedia" in navigator.mediaDevices, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+  });
 
 export const summarizer = (): Capability =>
   make(() => "Summarizer" in self, { requiresUserActivation: true, requiresSecureContext: true });
@@ -119,7 +115,7 @@ export const translator = (): Capability =>
   make(() => "Translator" in self, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const visibility = (): Capability =>
-  make(() => typeof document !== "undefined" && "visibilityState" in document, { requiresUserActivation: false });
+  make(() => "visibilityState" in document, { requiresUserActivation: false });
 
 export const wakeLock = (): Capability =>
   make(() => "wakeLock" in navigator, { requiresUserActivation: false, requiresSecureContext: true });

--- a/packages/pwafire/src/capability/index.ts
+++ b/packages/pwafire/src/capability/index.ts
@@ -1,0 +1,297 @@
+import type { Capability, CapabilityReason } from "../types/capability";
+
+const apiExists = (probe: () => boolean): boolean => {
+  try {
+    return probe();
+  } catch {
+    return false;
+  }
+};
+
+const inSecureContext = (): boolean =>
+  typeof window !== "undefined" && window.isSecureContext === true;
+
+const hasUserActivation = (): boolean =>
+  typeof navigator !== "undefined" && navigator.userActivation?.isActive === true;
+
+type Meta = {
+  requiresUserActivation: boolean;
+  requiresSecureContext?: boolean;
+  spec?: string;
+  mdn?: string;
+  since?: Capability["since"];
+};
+
+const make = (probe: () => boolean, meta: Meta): Capability => {
+  const secureContext = inSecureContext();
+  const { requiresUserActivation, requiresSecureContext, ...rest } = meta;
+  const base = { secureContext, requiresUserActivation, ...rest };
+  if (!apiExists(probe)) return { supported: false, reason: "no-api", ...base };
+  if (requiresSecureContext && !secureContext) return { supported: false, reason: "insecure-context", ...base };
+  if (requiresUserActivation && !hasUserActivation()) return { supported: false, reason: "no-user-activation", ...base };
+  return { supported: true, ...base };
+};
+
+const SPEC = {
+  badging: "https://w3c.github.io/badging/",
+  barcode: "https://wicg.github.io/shape-detection-api/",
+  broadcast: "https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts",
+  clipboard: "https://w3c.github.io/clipboard-apis/",
+  compression: "https://wicg.github.io/compression/",
+  connectivity: "https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-online",
+  contacts: "https://w3c.github.io/contact-api/",
+  contentIndexing: "https://wicg.github.io/content-index/spec/",
+  files: "https://wicg.github.io/file-system-access/",
+  fonts: "https://wicg.github.io/local-font-access/",
+  fullscreen: "https://fullscreen.spec.whatwg.org/",
+  idleDetection: "https://wicg.github.io/idle-detection/",
+  install: "https://web.dev/customize-install/",
+  languageDetector: "https://github.com/WICG/translation-api#language-detection",
+  lazyLoad: "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes",
+  notification: "https://notifications.spec.whatwg.org/",
+  passkey: "https://w3c.github.io/webauthn/",
+  payment: "https://w3c.github.io/payment-request/",
+  pip: "https://wicg.github.io/document-picture-in-picture/",
+  screenShare: "https://w3c.github.io/mediacapture-screen-share/",
+  summarizer: "https://github.com/WICG/writing-assistance-apis",
+  translator: "https://github.com/WICG/translation-api",
+  visibility: "https://www.w3.org/TR/page-visibility-2/",
+  wakeLock: "https://www.w3.org/TR/screen-wake-lock/",
+  webOtp: "https://wicg.github.io/web-otp/",
+  webShare: "https://www.w3.org/TR/web-share/",
+} as const;
+
+const MDN = {
+  badging: "https://developer.mozilla.org/docs/Web/API/Badging_API",
+  barcode: "https://developer.mozilla.org/docs/Web/API/Barcode_Detection_API",
+  broadcast: "https://developer.mozilla.org/docs/Web/API/Broadcast_Channel_API",
+  clipboard: "https://developer.mozilla.org/docs/Web/API/Clipboard_API",
+  compression: "https://developer.mozilla.org/docs/Web/API/Compression_Streams_API",
+  connectivity: "https://developer.mozilla.org/docs/Web/API/Navigator/onLine",
+  contacts: "https://developer.mozilla.org/docs/Web/API/Contact_Picker_API",
+  contentIndexing: "https://developer.mozilla.org/docs/Web/API/Content_Index_API",
+  files: "https://developer.mozilla.org/docs/Web/API/File_System_Access_API",
+  fonts: "https://developer.mozilla.org/docs/Web/API/Local_Font_Access_API",
+  fullscreen: "https://developer.mozilla.org/docs/Web/API/Fullscreen_API",
+  idleDetection: "https://developer.mozilla.org/docs/Web/API/Idle_Detection_API",
+  install: "https://developer.mozilla.org/docs/Web/Progressive_web_apps",
+  lazyLoad: "https://developer.mozilla.org/docs/Web/HTML/Element/img#loading",
+  notification: "https://developer.mozilla.org/docs/Web/API/Notifications_API",
+  passkey: "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API",
+  payment: "https://developer.mozilla.org/docs/Web/API/Payment_Request_API",
+  pip: "https://developer.mozilla.org/docs/Web/API/Document_Picture-in-Picture_API",
+  screenShare: "https://developer.mozilla.org/docs/Web/API/Screen_Capture_API",
+  visibility: "https://developer.mozilla.org/docs/Web/API/Page_Visibility_API",
+  wakeLock: "https://developer.mozilla.org/docs/Web/API/Screen_Wake_Lock_API",
+  webOtp: "https://developer.mozilla.org/docs/Web/API/WebOTP_API",
+  webShare: "https://developer.mozilla.org/docs/Web/API/Web_Share_API",
+} as const;
+
+export const badging = (): Capability =>
+  make(() => "setAppBadge" in navigator, {
+    requiresUserActivation: false,
+    requiresSecureContext: true,
+    spec: SPEC.badging,
+    mdn: MDN.badging,
+  });
+
+export const barcode = (): Capability =>
+  make(() => "BarcodeDetector" in window, {
+    requiresUserActivation: false,
+    spec: SPEC.barcode,
+    mdn: MDN.barcode,
+  });
+
+export const broadcast = (): Capability =>
+  make(() => "BroadcastChannel" in globalThis, {
+    requiresUserActivation: false,
+    spec: SPEC.broadcast,
+    mdn: MDN.broadcast,
+  });
+
+export const clipboard = (): Capability =>
+  make(() => "clipboard" in navigator, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.clipboard,
+    mdn: MDN.clipboard,
+  });
+
+export const compression = (): Capability =>
+  make(() => "CompressionStream" in window, {
+    requiresUserActivation: false,
+    spec: SPEC.compression,
+    mdn: MDN.compression,
+  });
+
+export const connectivity = (): Capability =>
+  make(() => typeof navigator !== "undefined" && "onLine" in navigator, {
+    requiresUserActivation: false,
+    spec: SPEC.connectivity,
+    mdn: MDN.connectivity,
+  });
+
+export const contacts = (): Capability =>
+  make(() => "contacts" in navigator && "ContactsManager" in window, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.contacts,
+    mdn: MDN.contacts,
+  });
+
+export const contentIndexing = (): Capability =>
+  make(() => "serviceWorker" in navigator, {
+    requiresUserActivation: false,
+    requiresSecureContext: true,
+    spec: SPEC.contentIndexing,
+    mdn: MDN.contentIndexing,
+  });
+
+export const files = (): Capability =>
+  make(() => "showOpenFilePicker" in self, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.files,
+    mdn: MDN.files,
+  });
+
+export const fonts = (): Capability =>
+  make(() => "queryLocalFonts" in window, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.fonts,
+    mdn: MDN.fonts,
+  });
+
+export const fullscreen = (): Capability =>
+  make(() => typeof document !== "undefined" && document.fullscreenEnabled === true, {
+    requiresUserActivation: true,
+    spec: SPEC.fullscreen,
+    mdn: MDN.fullscreen,
+  });
+
+export const idleDetection = (): Capability =>
+  make(() => "IdleDetector" in window, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.idleDetection,
+    mdn: MDN.idleDetection,
+  });
+
+export const install = (): Capability =>
+  make(() => "serviceWorker" in navigator, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.install,
+    mdn: MDN.install,
+  });
+
+export const languageDetector = (): Capability =>
+  make(() => "LanguageDetector" in self, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.languageDetector,
+  });
+
+export const lazyLoad = (): Capability =>
+  make(
+    () => typeof HTMLImageElement !== "undefined" && "loading" in HTMLImageElement.prototype,
+    {
+      requiresUserActivation: false,
+      spec: SPEC.lazyLoad,
+      mdn: MDN.lazyLoad,
+    },
+  );
+
+export const notification = (): Capability =>
+  make(() => "Notification" in window, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.notification,
+    mdn: MDN.notification,
+  });
+
+export const passkey = (): Capability =>
+  make(() => "PublicKeyCredential" in window && "credentials" in navigator, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.passkey,
+    mdn: MDN.passkey,
+  });
+
+export const payment = (): Capability =>
+  make(() => typeof window !== "undefined" && typeof window.PaymentRequest !== "undefined", {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.payment,
+    mdn: MDN.payment,
+  });
+
+export const pip = (): Capability =>
+  make(() => "documentPictureInPicture" in window, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.pip,
+    mdn: MDN.pip,
+  });
+
+export const screenShare = (): Capability =>
+  make(
+    () =>
+      typeof navigator !== "undefined" &&
+      !!navigator.mediaDevices &&
+      "getDisplayMedia" in navigator.mediaDevices,
+    {
+      requiresUserActivation: true,
+      requiresSecureContext: true,
+      spec: SPEC.screenShare,
+      mdn: MDN.screenShare,
+    },
+  );
+
+export const summarizer = (): Capability =>
+  make(() => "Summarizer" in self, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.summarizer,
+  });
+
+export const translator = (): Capability =>
+  make(() => "Translator" in self, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.translator,
+  });
+
+export const visibility = (): Capability =>
+  make(() => typeof document !== "undefined" && "visibilityState" in document, {
+    requiresUserActivation: false,
+    spec: SPEC.visibility,
+    mdn: MDN.visibility,
+  });
+
+export const wakeLock = (): Capability =>
+  make(() => "wakeLock" in navigator, {
+    requiresUserActivation: false,
+    requiresSecureContext: true,
+    spec: SPEC.wakeLock,
+    mdn: MDN.wakeLock,
+  });
+
+export const webOtp = (): Capability =>
+  make(() => "OTPCredential" in window, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.webOtp,
+    mdn: MDN.webOtp,
+  });
+
+export const webShare = (): Capability =>
+  make(() => "canShare" in navigator && "share" in navigator, {
+    requiresUserActivation: true,
+    requiresSecureContext: true,
+    spec: SPEC.webShare,
+    mdn: MDN.webShare,
+  });
+
+export type { Capability, CapabilityReason };

--- a/packages/pwafire/src/capability/index.ts
+++ b/packages/pwafire/src/capability/index.ts
@@ -70,8 +70,12 @@ export const fullscreen = (): Capability =>
 export const idleDetection = (): Capability =>
   make(() => "IdleDetector" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
+// `install()` just registers `appinstalled` / `beforeinstallprompt`
+// listeners (or fires a callback). Activation is only needed at the
+// downstream `BeforeInstallPromptEvent.prompt()` call, which is the
+// consumer's responsibility — not pwafire's call surface.
 export const install = (): Capability =>
-  make(() => "serviceWorker" in navigator, { requiresUserActivation: true, requiresSecureContext: true });
+  make(() => "serviceWorker" in navigator, { requiresUserActivation: false, requiresSecureContext: true });
 
 export const languageDetector = (): Capability =>
   make(() => "LanguageDetector" in self, { requiresUserActivation: true, requiresSecureContext: true });

--- a/packages/pwafire/src/capability/index.ts
+++ b/packages/pwafire/src/capability/index.ts
@@ -17,223 +17,87 @@ const hasUserActivation = (): boolean =>
 type Meta = {
   requiresUserActivation: boolean;
   requiresSecureContext?: boolean;
-  spec?: string;
-  mdn?: string;
-  since?: Capability["since"];
 };
 
 const make = (probe: () => boolean, meta: Meta): Capability => {
   const secureContext = inSecureContext();
-  const { requiresUserActivation, requiresSecureContext, ...rest } = meta;
-  const base = { secureContext, requiresUserActivation, ...rest };
+  const { requiresUserActivation, requiresSecureContext } = meta;
+  const base = { secureContext, requiresUserActivation };
   if (!apiExists(probe)) return { supported: false, reason: "no-api", ...base };
   if (requiresSecureContext && !secureContext) return { supported: false, reason: "insecure-context", ...base };
   if (requiresUserActivation && !hasUserActivation()) return { supported: false, reason: "no-user-activation", ...base };
   return { supported: true, ...base };
 };
 
-const SPEC = {
-  badging: "https://w3c.github.io/badging/",
-  barcode: "https://wicg.github.io/shape-detection-api/",
-  broadcast: "https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts",
-  clipboard: "https://w3c.github.io/clipboard-apis/",
-  compression: "https://wicg.github.io/compression/",
-  connectivity: "https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-online",
-  contacts: "https://w3c.github.io/contact-api/",
-  contentIndexing: "https://wicg.github.io/content-index/spec/",
-  files: "https://wicg.github.io/file-system-access/",
-  fonts: "https://wicg.github.io/local-font-access/",
-  fullscreen: "https://fullscreen.spec.whatwg.org/",
-  idleDetection: "https://wicg.github.io/idle-detection/",
-  install: "https://web.dev/customize-install/",
-  languageDetector: "https://github.com/WICG/translation-api#language-detection",
-  lazyLoad: "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes",
-  notification: "https://notifications.spec.whatwg.org/",
-  passkey: "https://w3c.github.io/webauthn/",
-  payment: "https://w3c.github.io/payment-request/",
-  pip: "https://wicg.github.io/document-picture-in-picture/",
-  screenShare: "https://w3c.github.io/mediacapture-screen-share/",
-  summarizer: "https://github.com/WICG/writing-assistance-apis",
-  translator: "https://github.com/WICG/translation-api",
-  visibility: "https://www.w3.org/TR/page-visibility-2/",
-  wakeLock: "https://www.w3.org/TR/screen-wake-lock/",
-  webOtp: "https://wicg.github.io/web-otp/",
-  webShare: "https://www.w3.org/TR/web-share/",
-} as const;
-
-const MDN = {
-  badging: "https://developer.mozilla.org/docs/Web/API/Badging_API",
-  barcode: "https://developer.mozilla.org/docs/Web/API/Barcode_Detection_API",
-  broadcast: "https://developer.mozilla.org/docs/Web/API/Broadcast_Channel_API",
-  clipboard: "https://developer.mozilla.org/docs/Web/API/Clipboard_API",
-  compression: "https://developer.mozilla.org/docs/Web/API/Compression_Streams_API",
-  connectivity: "https://developer.mozilla.org/docs/Web/API/Navigator/onLine",
-  contacts: "https://developer.mozilla.org/docs/Web/API/Contact_Picker_API",
-  contentIndexing: "https://developer.mozilla.org/docs/Web/API/Content_Index_API",
-  files: "https://developer.mozilla.org/docs/Web/API/File_System_Access_API",
-  fonts: "https://developer.mozilla.org/docs/Web/API/Local_Font_Access_API",
-  fullscreen: "https://developer.mozilla.org/docs/Web/API/Fullscreen_API",
-  idleDetection: "https://developer.mozilla.org/docs/Web/API/Idle_Detection_API",
-  install: "https://developer.mozilla.org/docs/Web/Progressive_web_apps",
-  lazyLoad: "https://developer.mozilla.org/docs/Web/HTML/Element/img#loading",
-  notification: "https://developer.mozilla.org/docs/Web/API/Notifications_API",
-  passkey: "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API",
-  payment: "https://developer.mozilla.org/docs/Web/API/Payment_Request_API",
-  pip: "https://developer.mozilla.org/docs/Web/API/Document_Picture-in-Picture_API",
-  screenShare: "https://developer.mozilla.org/docs/Web/API/Screen_Capture_API",
-  visibility: "https://developer.mozilla.org/docs/Web/API/Page_Visibility_API",
-  wakeLock: "https://developer.mozilla.org/docs/Web/API/Screen_Wake_Lock_API",
-  webOtp: "https://developer.mozilla.org/docs/Web/API/WebOTP_API",
-  webShare: "https://developer.mozilla.org/docs/Web/API/Web_Share_API",
-} as const;
-
 export const badging = (): Capability =>
-  make(() => "setAppBadge" in navigator, {
-    requiresUserActivation: false,
-    requiresSecureContext: true,
-    spec: SPEC.badging,
-    mdn: MDN.badging,
-  });
+  make(() => "setAppBadge" in navigator, { requiresUserActivation: false, requiresSecureContext: true });
 
 export const barcode = (): Capability =>
-  make(() => "BarcodeDetector" in window, {
-    requiresUserActivation: false,
-    spec: SPEC.barcode,
-    mdn: MDN.barcode,
-  });
+  make(() => "BarcodeDetector" in window, { requiresUserActivation: false });
 
 export const broadcast = (): Capability =>
-  make(() => "BroadcastChannel" in globalThis, {
-    requiresUserActivation: false,
-    spec: SPEC.broadcast,
-    mdn: MDN.broadcast,
-  });
+  make(() => "BroadcastChannel" in globalThis, { requiresUserActivation: false });
 
 export const clipboard = (): Capability =>
-  make(() => "clipboard" in navigator, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.clipboard,
-    mdn: MDN.clipboard,
-  });
+  make(() => "clipboard" in navigator, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const compression = (): Capability =>
-  make(() => "CompressionStream" in window, {
-    requiresUserActivation: false,
-    spec: SPEC.compression,
-    mdn: MDN.compression,
-  });
+  make(() => "CompressionStream" in window, { requiresUserActivation: false });
 
 export const connectivity = (): Capability =>
-  make(() => typeof navigator !== "undefined" && "onLine" in navigator, {
-    requiresUserActivation: false,
-    spec: SPEC.connectivity,
-    mdn: MDN.connectivity,
-  });
+  make(() => typeof navigator !== "undefined" && "onLine" in navigator, { requiresUserActivation: false });
 
 export const contacts = (): Capability =>
   make(() => "contacts" in navigator && "ContactsManager" in window, {
     requiresUserActivation: true,
     requiresSecureContext: true,
-    spec: SPEC.contacts,
-    mdn: MDN.contacts,
   });
 
 export const contentIndexing = (): Capability =>
-  make(() => "serviceWorker" in navigator, {
-    requiresUserActivation: false,
-    requiresSecureContext: true,
-    spec: SPEC.contentIndexing,
-    mdn: MDN.contentIndexing,
-  });
+  make(() => "serviceWorker" in navigator, { requiresUserActivation: false, requiresSecureContext: true });
 
 export const files = (): Capability =>
-  make(() => "showOpenFilePicker" in self, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.files,
-    mdn: MDN.files,
-  });
+  make(() => "showOpenFilePicker" in self, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const fonts = (): Capability =>
-  make(() => "queryLocalFonts" in window, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.fonts,
-    mdn: MDN.fonts,
-  });
+  make(() => "queryLocalFonts" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const fullscreen = (): Capability =>
   make(() => typeof document !== "undefined" && document.fullscreenEnabled === true, {
     requiresUserActivation: true,
-    spec: SPEC.fullscreen,
-    mdn: MDN.fullscreen,
   });
 
 export const idleDetection = (): Capability =>
-  make(() => "IdleDetector" in window, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.idleDetection,
-    mdn: MDN.idleDetection,
-  });
+  make(() => "IdleDetector" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const install = (): Capability =>
-  make(() => "serviceWorker" in navigator, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.install,
-    mdn: MDN.install,
-  });
+  make(() => "serviceWorker" in navigator, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const languageDetector = (): Capability =>
-  make(() => "LanguageDetector" in self, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.languageDetector,
-  });
+  make(() => "LanguageDetector" in self, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const lazyLoad = (): Capability =>
-  make(
-    () => typeof HTMLImageElement !== "undefined" && "loading" in HTMLImageElement.prototype,
-    {
-      requiresUserActivation: false,
-      spec: SPEC.lazyLoad,
-      mdn: MDN.lazyLoad,
-    },
-  );
+  make(() => typeof HTMLImageElement !== "undefined" && "loading" in HTMLImageElement.prototype, {
+    requiresUserActivation: false,
+  });
 
 export const notification = (): Capability =>
-  make(() => "Notification" in window, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.notification,
-    mdn: MDN.notification,
-  });
+  make(() => "Notification" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const passkey = (): Capability =>
   make(() => "PublicKeyCredential" in window && "credentials" in navigator, {
     requiresUserActivation: true,
     requiresSecureContext: true,
-    spec: SPEC.passkey,
-    mdn: MDN.passkey,
   });
 
 export const payment = (): Capability =>
   make(() => typeof window !== "undefined" && typeof window.PaymentRequest !== "undefined", {
     requiresUserActivation: true,
     requiresSecureContext: true,
-    spec: SPEC.payment,
-    mdn: MDN.payment,
   });
 
 export const pip = (): Capability =>
-  make(() => "documentPictureInPicture" in window, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.pip,
-    mdn: MDN.pip,
-  });
+  make(() => "documentPictureInPicture" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const screenShare = (): Capability =>
   make(
@@ -241,57 +105,28 @@ export const screenShare = (): Capability =>
       typeof navigator !== "undefined" &&
       !!navigator.mediaDevices &&
       "getDisplayMedia" in navigator.mediaDevices,
-    {
-      requiresUserActivation: true,
-      requiresSecureContext: true,
-      spec: SPEC.screenShare,
-      mdn: MDN.screenShare,
-    },
+    { requiresUserActivation: true, requiresSecureContext: true },
   );
 
 export const summarizer = (): Capability =>
-  make(() => "Summarizer" in self, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.summarizer,
-  });
+  make(() => "Summarizer" in self, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const translator = (): Capability =>
-  make(() => "Translator" in self, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.translator,
-  });
+  make(() => "Translator" in self, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const visibility = (): Capability =>
-  make(() => typeof document !== "undefined" && "visibilityState" in document, {
-    requiresUserActivation: false,
-    spec: SPEC.visibility,
-    mdn: MDN.visibility,
-  });
+  make(() => typeof document !== "undefined" && "visibilityState" in document, { requiresUserActivation: false });
 
 export const wakeLock = (): Capability =>
-  make(() => "wakeLock" in navigator, {
-    requiresUserActivation: false,
-    requiresSecureContext: true,
-    spec: SPEC.wakeLock,
-    mdn: MDN.wakeLock,
-  });
+  make(() => "wakeLock" in navigator, { requiresUserActivation: false, requiresSecureContext: true });
 
 export const webOtp = (): Capability =>
-  make(() => "OTPCredential" in window, {
-    requiresUserActivation: true,
-    requiresSecureContext: true,
-    spec: SPEC.webOtp,
-    mdn: MDN.webOtp,
-  });
+  make(() => "OTPCredential" in window, { requiresUserActivation: true, requiresSecureContext: true });
 
 export const webShare = (): Capability =>
   make(() => "canShare" in navigator && "share" in navigator, {
     requiresUserActivation: true,
     requiresSecureContext: true,
-    spec: SPEC.webShare,
-    mdn: MDN.webShare,
   });
 
 export type { Capability, CapabilityReason };

--- a/packages/pwafire/src/check/index.ts
+++ b/packages/pwafire/src/check/index.ts
@@ -1,25 +1,50 @@
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const badging = () => "setAppBadge" in navigator;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const barcode = () => "BarcodeDetector" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const broadcast = () => "BroadcastChannel" in globalThis;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const clipboard = () => "clipboard" in navigator;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const compression = () => "CompressionStream" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const connectivity = () => "connection" in navigator;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const contacts = () => "contacts" in navigator;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const contentIndexing = () => "index" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const files = () => "showOpenFilePicker" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const fonts = () => "queryLocalFonts" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const fullscreen = () => "requestFullscreen" in document.documentElement;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const idleDetection = () => "IdleDetector" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const install = () => "getInstalledRelatedApps" in navigator;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const languageDetector = () => "LanguageDetector" in self;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const lazyLoad = () => "loading" in HTMLImageElement.prototype;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const notification = () => "Notification" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const passkey = () => "PublicKeyCredential" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const payment = () => typeof window.PaymentRequest !== "undefined";
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const screenShare = () => "getDisplayMedia" in navigator.mediaDevices;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const summarizer = () => "Summarizer" in self;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const translator = () => "Translator" in self;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const visibility = () => "visibilityState" in document;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const wakeLock = () => "wakeLock" in navigator;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const webOtp = () => "OTPCredential" in window;
+/** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const webShare = () => "share" in navigator;

--- a/packages/pwafire/src/check/index.ts
+++ b/packages/pwafire/src/check/index.ts
@@ -9,7 +9,10 @@ export const clipboard = () => "clipboard" in navigator;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const compression = () => "CompressionStream" in window;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
-export const connectivity = () => "connection" in navigator;
+// Probes navigator.onLine — what `pwa/connectivity` actually reads.
+// Earlier versions probed `connection` (Network Information API),
+// which is a different feature.
+export const connectivity = () => "onLine" in navigator;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const contacts = () => "contacts" in navigator;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
@@ -19,7 +22,10 @@ export const files = () => "showOpenFilePicker" in window;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const fonts = () => "queryLocalFonts" in window;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
-export const fullscreen = () => "requestFullscreen" in document.documentElement;
+// `document.fullscreenEnabled` honors Permissions-Policy and iframe
+// `allowfullscreen` — the actual gating `pwa/fullscreen` faces.
+// Mere method presence isn't sufficient.
+export const fullscreen = () => typeof document !== "undefined" && document.fullscreenEnabled === true;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const idleDetection = () => "IdleDetector" in window;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
@@ -33,7 +39,8 @@ export const lazyLoad = () => "loading" in HTMLImageElement.prototype;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const notification = () => "Notification" in window;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
-export const passkey = () => "PublicKeyCredential" in window;
+// `pwa/passkey` needs both the credential type and `navigator.credentials`.
+export const passkey = () => "PublicKeyCredential" in window && "credentials" in navigator;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const payment = () => typeof window.PaymentRequest !== "undefined";
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */

--- a/packages/pwafire/src/check/index.ts
+++ b/packages/pwafire/src/check/index.ts
@@ -23,7 +23,9 @@ export const fullscreen = () => "requestFullscreen" in document.documentElement;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const idleDetection = () => "IdleDetector" in window;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
-export const install = () => "getInstalledRelatedApps" in navigator;
+// Probes navigator.serviceWorker — the actual prerequisite for `pwafire.install()`.
+// Earlier versions probed `getInstalledRelatedApps`, which answers a different question.
+export const install = () => "serviceWorker" in navigator;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */
 export const languageDetector = () => "LanguageDetector" in self;
 /** @deprecated Use `pwafire/capability` — `.supported` is the boolean. Removed in v7. */

--- a/packages/pwafire/src/index.ts
+++ b/packages/pwafire/src/index.ts
@@ -24,6 +24,9 @@ export * from "./pwa/wake-lock";
 export * from "./pwa/web-otp";
 export * from "./pwa/web-share";
 
+export type { ErrorCode, ResultMeta } from "./types/result";
+export type { Capability, CapabilityReason } from "./types/capability";
+
 import * as pwa from "./pwa";
 import * as check from "./check";
 

--- a/packages/pwafire/src/index.ts
+++ b/packages/pwafire/src/index.ts
@@ -29,5 +29,6 @@ export type { Capability, CapabilityReason } from "./types/capability";
 
 import * as pwa from "./pwa";
 import * as check from "./check";
+import * as capability from "./capability";
 
-export { pwa, check };
+export { pwa, check, capability };

--- a/packages/pwafire/src/pwa/badging/index.ts
+++ b/packages/pwafire/src/pwa/badging/index.ts
@@ -1,34 +1,55 @@
-export const setBadge = async (unreadCount: number) => {
+import type { ErrorCode } from "../../types/result";
+
+/**
+ * Sets the application badge to `unreadCount`.
+ *
+ * Browsers display the badge on the installed PWA icon. Requires a
+ * secure context.
+ *
+ * @see https://w3c.github.io/badging/
+ */
+export const setBadge = async (
+  unreadCount: number,
+): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
   try {
-    if (navigator.setAppBadge) {
-      await navigator.setAppBadge(unreadCount);
-      return { ok: true, message: "Set" };
-    } else {
-      return {
-        ok: false,
-        message: "Badging API not supported",
-      };
+    if (!navigator.setAppBadge) {
+      return { ok: false, code: "unsupported", message: "Badging API not supported" };
     }
+    await navigator.setAppBadge(unreadCount);
+    return { ok: true, message: "Set" };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to set badge",
+      cause: error,
     };
   }
 };
 
-export const clearBadge = async () => {
+/**
+ * Clears the application badge.
+ *
+ * @see https://w3c.github.io/badging/#dom-navigator-clearappbadge
+ */
+export const clearBadge = async (): Promise<{
+  ok: boolean;
+  message: string;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if (navigator.clearAppBadge) {
-      await navigator.clearAppBadge();
-      return { ok: true, message: "Cleared" };
-    } else {
-      return { ok: false, message: "Badging API not supported" };
+    if (!navigator.clearAppBadge) {
+      return { ok: false, code: "unsupported", message: "Badging API not supported" };
     }
+    await navigator.clearAppBadge();
+    return { ok: true, message: "Cleared" };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to clear badge",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/badging/index.ts
+++ b/packages/pwafire/src/pwa/badging/index.ts
@@ -1,13 +1,5 @@
 import type { ErrorCode } from "../../types/result";
 
-/**
- * Sets the application badge to `unreadCount`.
- *
- * Browsers display the badge on the installed PWA icon. Requires a
- * secure context.
- *
- * @see https://w3c.github.io/badging/
- */
 export const setBadge = async (
   unreadCount: number,
 ): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
@@ -27,11 +19,6 @@ export const setBadge = async (
   }
 };
 
-/**
- * Clears the application badge.
- *
- * @see https://w3c.github.io/badging/#dom-navigator-clearappbadge
- */
 export const clearBadge = async (): Promise<{
   ok: boolean;
   message: string;

--- a/packages/pwafire/src/pwa/barcode/index.ts
+++ b/packages/pwafire/src/pwa/barcode/index.ts
@@ -1,3 +1,5 @@
+import type { ErrorCode } from "../../types/result";
+
 export const barcodeDetector = async (options: {
   image: Blob | HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | ImageBitmap;
   format:
@@ -14,36 +16,40 @@ export const barcodeDetector = async (options: {
     | "qr_code"
     | "upc_a"
     | "upc_e";
-}) => {
+}): Promise<{
+  ok: boolean;
+  message: string;
+  barcodes?: unknown[];
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("BarcodeDetector" in window) {
-      const formatSupported = (await BarcodeDetector.getSupportedFormats()).includes(options.format);
-      if (formatSupported) {
-        const barcodeDetector = new BarcodeDetector({
-          formats: [options.format],
-        });
-        const barcodes = await (barcodeDetector as any).detect(options.image);
-        return {
-          ok: barcodes ? true : false,
-          message: barcodes ? "Barcode detected" : "No barcode detected",
-          barcodes,
-        };
-      } else {
-        return {
-          ok: false,
-          message: `Sorry, "${options.format.charAt(0).toUpperCase() + options.format.slice(1)}" format not supported`,
-        };
-      }
-    } else {
+    if (!("BarcodeDetector" in window)) {
+      return { ok: false, code: "unsupported", message: "Barcode Detector API not supported" };
+    }
+    const formatSupported = (await BarcodeDetector.getSupportedFormats()).includes(options.format);
+    if (!formatSupported) {
       return {
         ok: false,
-        message: "Barcode Detector API not supported",
+        code: "unsupported",
+        message: `Sorry, "${options.format.charAt(0).toUpperCase() + options.format.slice(1)}" format not supported`,
       };
     }
+    const barcodeDetector = new BarcodeDetector({
+      formats: [options.format],
+    });
+    const barcodes = await (barcodeDetector as any).detect(options.image);
+    return {
+      ok: barcodes ? true : false,
+      message: barcodes ? "Barcode detected" : "No barcode detected",
+      barcodes,
+    };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to detect barcode",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/broadcast/index.ts
+++ b/packages/pwafire/src/pwa/broadcast/index.ts
@@ -1,10 +1,21 @@
+import type { ErrorCode } from "../../types/result";
+
 const DEFAULT_CHANNEL_NAME = "pwafire-broadcast-demo";
 
-const channel = (name: string) => {
+const channel = (
+  name: string,
+): {
+  ok: boolean;
+  message: string;
+  channel: BroadcastChannel | null;
+  code?: ErrorCode;
+  cause?: unknown;
+} => {
   try {
     if (!("BroadcastChannel" in globalThis)) {
       return {
         ok: false as const,
+        code: "unsupported",
         message: "Broadcast Channel API not supported",
         channel: null,
       };
@@ -18,13 +29,23 @@ const channel = (name: string) => {
   } catch (error) {
     return {
       ok: false as const,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to create channel",
       channel: null,
+      cause: error,
     };
   }
 };
 
-const send = (channelName = DEFAULT_CHANNEL_NAME) => {
+const send = (
+  channelName = DEFAULT_CHANNEL_NAME,
+): {
+  ok: boolean;
+  message: string;
+  channel?: BroadcastChannel | null;
+  code?: ErrorCode;
+  cause?: unknown;
+} => {
   try {
     const result = channel(channelName);
     if (!result.ok || !result.channel) {
@@ -40,15 +61,23 @@ const send = (channelName = DEFAULT_CHANNEL_NAME) => {
   } catch (error) {
     return {
       ok: false as const,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to broadcast",
+      cause: error,
     };
   }
 };
 
 const listen = (
   channelName = DEFAULT_CHANNEL_NAME,
-  onMessage?: (data: unknown) => void
-) => {
+  onMessage?: (data: unknown) => void,
+): {
+  ok: boolean;
+  message: string;
+  channel?: BroadcastChannel | null;
+  code?: ErrorCode;
+  cause?: unknown;
+} => {
   try {
     const result = channel(channelName);
     if (!result.ok || !result.channel) {
@@ -66,7 +95,9 @@ const listen = (
   } catch (error) {
     return {
       ok: false as const,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to listen",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/clipboard/index.ts
+++ b/packages/pwafire/src/pwa/clipboard/index.ts
@@ -1,60 +1,100 @@
-export const copyText = async (text: string): Promise<{ ok: boolean; message: string }> => {
+import type { ErrorCode } from "../../types/result";
+
+const errorCodeFor = (error: unknown): ErrorCode => {
+  if (error instanceof DOMException && error.name === "NotAllowedError") {
+    return "permission-denied";
+  }
+  return "runtime-error";
+};
+
+/**
+ * Writes text to the system clipboard via the async Clipboard API.
+ *
+ * Requires a secure context. Most browsers require recent user
+ * activation; without it, the call rejects with `permission-denied`.
+ *
+ * @see https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext
+ */
+export const copyText = async (
+  text: string,
+): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
   try {
-    if (navigator.clipboard) {
-      await navigator.clipboard.writeText(text);
-      return { ok: true, message: "Copied" };
-    } else {
-      return {
-        ok: false,
-        message: "Copy Text API not supported",
-      };
+    if (!navigator.clipboard) {
+      return { ok: false, code: "unsupported", message: "Copy Text API not supported" };
     }
+    await navigator.clipboard.writeText(text);
+    return { ok: true, message: "Copied" };
   } catch (error) {
     return {
       ok: false,
+      code: errorCodeFor(error),
       message: error instanceof Error ? error.message : "Failed to copy text",
+      cause: error,
     };
   }
 };
 
-export const readText = async (): Promise<{ ok: boolean; message: string; text: string | null }> => {
+/**
+ * Reads plain text from the system clipboard.
+ *
+ * Requires a secure context and (in most browsers) user activation.
+ * Some browsers also surface a one-time permission prompt.
+ *
+ * @see https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext
+ */
+export const readText = async (): Promise<{
+  ok: boolean;
+  message: string;
+  text: string | null;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if (navigator.clipboard) {
-      const text = await navigator.clipboard.readText();
-      return { ok: true, message: "Read", text };
-    } else {
-      return { ok: false, message: "Read Text API not supported", text: null };
+    if (!navigator.clipboard) {
+      return { ok: false, code: "unsupported", message: "Read Text API not supported", text: null };
     }
+    const text = await navigator.clipboard.readText();
+    return { ok: true, message: "Read", text };
   } catch (error) {
     return {
       ok: false,
+      code: errorCodeFor(error),
       message: error instanceof Error ? error.message : "Failed to read text",
       text: null,
+      cause: error,
     };
   }
 };
 
-export const copyImage = async (imgURL: string) => {
+/**
+ * Fetches an image URL and writes it to the clipboard as a `ClipboardItem`.
+ *
+ * Requires a secure context. The blob's MIME type must be one the
+ * platform supports (typically `image/png`).
+ *
+ * @see https://w3c.github.io/clipboard-apis/#dom-clipboard-write
+ */
+export const copyImage = async (
+  imgURL: string,
+): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
   try {
-    if (navigator.clipboard) {
-      const data = await fetch(imgURL);
-      const blob = await data.blob();
-      await navigator.clipboard.write([
-        new ClipboardItem({
-          [blob.type]: blob,
-        }),
-      ]);
-      return {
-        ok: true,
-        message: "Image copied",
-      };
-    } else {
-      return { ok: false, message: "Copy Image API not supported" };
+    if (!navigator.clipboard) {
+      return { ok: false, code: "unsupported", message: "Copy Image API not supported" };
     }
+    const data = await fetch(imgURL);
+    const blob = await data.blob();
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        [blob.type]: blob,
+      }),
+    ]);
+    return { ok: true, message: "Image copied" };
   } catch (error) {
     return {
       ok: false,
+      code: errorCodeFor(error),
       message: error instanceof Error ? error.message : "Failed to copy image",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/clipboard/index.ts
+++ b/packages/pwafire/src/pwa/clipboard/index.ts
@@ -7,14 +7,6 @@ const errorCodeFor = (error: unknown): ErrorCode => {
   return "runtime-error";
 };
 
-/**
- * Writes text to the system clipboard via the async Clipboard API.
- *
- * Requires a secure context. Most browsers require recent user
- * activation; without it, the call rejects with `permission-denied`.
- *
- * @see https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext
- */
 export const copyText = async (
   text: string,
 ): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
@@ -34,14 +26,6 @@ export const copyText = async (
   }
 };
 
-/**
- * Reads plain text from the system clipboard.
- *
- * Requires a secure context and (in most browsers) user activation.
- * Some browsers also surface a one-time permission prompt.
- *
- * @see https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext
- */
 export const readText = async (): Promise<{
   ok: boolean;
   message: string;
@@ -66,14 +50,6 @@ export const readText = async (): Promise<{
   }
 };
 
-/**
- * Fetches an image URL and writes it to the clipboard as a `ClipboardItem`.
- *
- * Requires a secure context. The blob's MIME type must be one the
- * platform supports (typically `image/png`).
- *
- * @see https://w3c.github.io/clipboard-apis/#dom-clipboard-write
- */
 export const copyImage = async (
   imgURL: string,
 ): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {

--- a/packages/pwafire/src/pwa/codes.test.ts
+++ b/packages/pwafire/src/pwa/codes.test.ts
@@ -1,0 +1,143 @@
+// Pins every `ErrorCode` literal to a concrete API call site so the v6.5
+// typed-error contract can't drift quietly. One representative test per
+// code; each cites the spec section that defines the DOMException name
+// being mapped (or the secure-context / activation requirement being
+// honored).
+
+import { wakeLock } from "./wake-lock";
+import { payment } from "./payment";
+import { copyText } from "./clipboard";
+import { notification } from "./notification";
+import { webShare } from "./web-share";
+import { passkey } from "./passkey";
+import { compressStream } from "./compression";
+
+type AnyNav = Record<string, unknown>;
+type AnyWin = Record<string, unknown>;
+
+const setNav = (key: string, value: unknown): void => {
+  Object.defineProperty(navigator, key, { configurable: true, value });
+};
+const deleteNav = (key: string): void => {
+  delete (navigator as unknown as AnyNav)[key];
+};
+const setWin = (key: string, value: unknown): void => {
+  Object.defineProperty(window, key, { configurable: true, value });
+};
+
+describe("ErrorCode contract", () => {
+  beforeEach(() => {
+    // Reset everything tests below touch so each starts from a known state.
+    deleteNav("wakeLock");
+    deleteNav("clipboard");
+    deleteNav("share");
+    deleteNav("canShare");
+    deleteNav("userActivation");
+    delete (window as unknown as AnyWin).PaymentRequest;
+    delete (window as unknown as AnyWin).Notification;
+    delete (window as unknown as AnyWin).CompressionStream;
+    delete (window as unknown as AnyWin).PublicKeyCredential;
+  });
+
+  it("'unsupported' — wakeLock returns it when navigator.wakeLock is missing", async () => {
+    // Pre-condition: API not present on the platform. The check is the
+    // first line of every pwafire API and predates DOMException entirely.
+    const r = await wakeLock();
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("unsupported");
+  });
+
+  it("'insecure-context' — payment surfaces it when window.isSecureContext is false", async () => {
+    // PaymentRequest is gated behind a secure context per
+    // https://w3c.github.io/payment-request/#constructor — pwafire surfaces
+    // this proactively instead of letting the constructor throw.
+    setWin("PaymentRequest", function PaymentRequestMock() {});
+    setWin("isSecureContext", false);
+    const r = await payment(
+      { methodData: [], details: { total: { label: "", amount: { currency: "USD", value: "0" } } } },
+      () => true,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("insecure-context");
+  });
+
+  it("'permission-denied' — clipboard.copyText maps NotAllowedError", async () => {
+    // https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext —
+    // rejects with "NotAllowedError" DOMException when the page lacks
+    // write permission (no focus, no transient activation, denied prompt).
+    setNav("clipboard", {
+      writeText: () => Promise.reject(new DOMException("blocked", "NotAllowedError")),
+    });
+    const r = await copyText("x");
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("permission-denied");
+    expect(r.cause).toBeInstanceOf(DOMException);
+  });
+
+  it("'permission-dismissed' — notification surfaces it when permission stays 'default'", async () => {
+    // https://notifications.spec.whatwg.org/#permission-model —
+    // requestPermission() resolves to "default" when the user dismisses
+    // the prompt without choosing allow or deny.
+    setWin("Notification", { requestPermission: () => Promise.resolve("default") });
+    const r = await notification({ title: "t", options: { body: "b", timestamp: 0 } });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("permission-dismissed");
+    // Legacy field preserved (v6.5 strictly additive).
+    expect(r.status).toBe("permission-default");
+  });
+
+  it("'gesture-required' — payment surfaces it when navigator.userActivation.isActive is false", async () => {
+    // PaymentRequest.show() requires transient user activation per
+    // https://html.spec.whatwg.org/multipage/interaction.html#transient-activation
+    // pwafire reads navigator.userActivation.isActive before calling show().
+    setWin("PaymentRequest", function PaymentRequestMock() {});
+    setWin("isSecureContext", true);
+    setNav("userActivation", { isActive: false });
+    const r = await payment(
+      { methodData: [], details: { total: { label: "", amount: { currency: "USD", value: "0" } } } },
+      () => true,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("gesture-required");
+  });
+
+  it("'cancelled' — webShare maps AbortError", async () => {
+    // https://www.w3.org/TR/web-share/#share-method —
+    // share() rejects with "AbortError" DOMException when the user
+    // dismisses the OS share sheet.
+    setNav("canShare", () => true);
+    setNav("share", () => Promise.reject(new DOMException("user dismissed", "AbortError")));
+    const r = await webShare({ text: "x" });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("cancelled");
+  });
+
+  it("'invalid-argument' — passkey.parseCreationOptions surfaces it when parse throws", () => {
+    // https://w3c.github.io/webauthn/#sctn-parseCreationOptionsFromJSON —
+    // parseCreationOptionsFromJSON throws (typically TypeError) on
+    // malformed JSON input.
+    (window as unknown as AnyWin).PublicKeyCredential = {
+      parseCreationOptionsFromJSON: () => {
+        throw new TypeError("malformed");
+      },
+    };
+    const r = passkey.parseCreationOptions({});
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("invalid-argument");
+  });
+
+  it("'runtime-error' — compressStream falls back to it on unexpected throw", async () => {
+    // Catch-all for errors that don't match a known DOMException name.
+    // Here the constructor itself throws after the feature-detect passes.
+    setWin("CompressionStream", function CompressionStreamMock() {
+      throw new Error("boom");
+    });
+    // jsdom doesn't define ReadableStream; the mocked CompressionStream
+    // constructor throws before pipeThrough is dereferenced, so a stub
+    // value is enough here.
+    const r = await compressStream({} as unknown as ReadableStream);
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("runtime-error");
+    expect(r.cause).toBeInstanceOf(Error);
+  });
+});

--- a/packages/pwafire/src/pwa/codes.test.ts
+++ b/packages/pwafire/src/pwa/codes.test.ts
@@ -11,6 +11,7 @@ import { notification } from "./notification";
 import { webShare } from "./web-share";
 import { passkey } from "./passkey";
 import { compressStream } from "./compression";
+import { webOtp } from "./web-otp";
 
 type AnyNav = Record<string, unknown>;
 type AnyWin = Record<string, unknown>;
@@ -37,6 +38,7 @@ describe("ErrorCode contract", () => {
     delete (window as unknown as AnyWin).Notification;
     delete (window as unknown as AnyWin).CompressionStream;
     delete (window as unknown as AnyWin).PublicKeyCredential;
+    delete (window as unknown as AnyWin).OTPCredential;
   });
 
   it("'unsupported' — wakeLock returns it when navigator.wakeLock is missing", async () => {
@@ -139,5 +141,47 @@ describe("ErrorCode contract", () => {
     expect(r.ok).toBe(false);
     expect(r.code).toBe("runtime-error");
     expect(r.cause).toBeInstanceOf(Error);
+  });
+
+  // --- extra contract pinning ---
+
+  it("webOtp uses `errorCode` (not `code`) for the discriminator — pins the v7 rename", async () => {
+    // The OTPCredential payload itself uses `code` for the SMS value,
+    // so v6.5 exposes the ErrorCode discriminator as `errorCode` and
+    // mirrors the OTP value to `otpCode`. v7 frees up `code` for the
+    // ErrorCode (same as everywhere else). Test pins the field name
+    // so the divergence can't drift accidentally.
+    const r = await webOtp();
+    expect(r.ok).toBe(false);
+    expect(r.errorCode).toBe("unsupported");
+    // The OTP-value field stays `code`, kept null on failure.
+    expect(r.code).toBeNull();
+    expect(r.otpCode).toBeNull();
+  });
+
+  it("notification permission='denied' maps to 'permission-denied' (vs 'default' → 'permission-dismissed')", async () => {
+    // The spec distinguishes "denied" (user actively blocked) from
+    // "default" (user dismissed without choosing). pwafire mirrors
+    // that distinction in `code` so consumers can offer a different
+    // affordance for each.
+    setWin("Notification", { requestPermission: () => Promise.resolve("denied") });
+    const r = await notification({ title: "t", options: { body: "b", timestamp: 0 } });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("permission-denied");
+    expect(r.status).toBe("permission-denied"); // legacy field also updated
+  });
+
+  it("`cause` round-trips a non-Error throw value verbatim", async () => {
+    // Code does `error instanceof Error ? error.message : "..."` so
+    // non-Error throws fall through to the fallback message — but
+    // `cause` should still carry the original thrown value untouched
+    // for diagnostics.
+    setNav("clipboard", {
+      writeText: () => Promise.reject("raw string thrown"),
+    });
+    const r = await copyText("x");
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("runtime-error");
+    expect(r.cause).toBe("raw string thrown");
   });
 });

--- a/packages/pwafire/src/pwa/compression/index.ts
+++ b/packages/pwafire/src/pwa/compression/index.ts
@@ -1,43 +1,57 @@
-export const compressStream = async (readableStream: ReadableStream) => {
+import type { ErrorCode } from "../../types/result";
+
+export const compressStream = async (
+  readableStream: ReadableStream,
+): Promise<{
+  ok: boolean;
+  message: string;
+  stream?: ReadableStream;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("CompressionStream" in window) {
-      return {
-        ok: true,
-        message: "Compressed",
-        stream: readableStream.pipeThrough(new CompressionStream("gzip")),
-      };
-    } else {
-      return {
-        ok: false,
-        message: "Compression Streams API not supported",
-      };
+    if (!("CompressionStream" in window)) {
+      return { ok: false, code: "unsupported", message: "Compression Streams API not supported" };
     }
+    return {
+      ok: true,
+      message: "Compressed",
+      stream: readableStream.pipeThrough(new CompressionStream("gzip")),
+    };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to compress stream",
+      cause: error,
     };
   }
 };
 
-export const decompressStream = async (compressedReadableStream: ReadableStream) => {
+export const decompressStream = async (
+  compressedReadableStream: ReadableStream,
+): Promise<{
+  ok: boolean;
+  message: string;
+  stream?: ReadableStream;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("DecompressionStream" in window) {
-      return {
-        ok: true,
-        message: "Decompressed",
-        stream: compressedReadableStream.pipeThrough(new DecompressionStream("gzip")),
-      };
-    } else {
-      return {
-        ok: false,
-        message: "DeCompression Streams API not supported",
-      };
+    if (!("DecompressionStream" in window)) {
+      return { ok: false, code: "unsupported", message: "DeCompression Streams API not supported" };
     }
+    return {
+      ok: true,
+      message: "Decompressed",
+      stream: compressedReadableStream.pipeThrough(new DecompressionStream("gzip")),
+    };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to decompress stream",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/connectivity/index.ts
+++ b/packages/pwafire/src/pwa/connectivity/index.ts
@@ -1,4 +1,12 @@
-export const connectivity = () => {
+import type { ErrorCode } from "../../types/result";
+
+export const connectivity = (): {
+  ok: boolean;
+  message: string;
+  online: boolean;
+  code?: ErrorCode;
+  cause?: unknown;
+} => {
   try {
     const isOnline = navigator.onLine;
     return {
@@ -9,8 +17,10 @@ export const connectivity = () => {
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to check connectivity",
       online: false,
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/contacts/index.ts
+++ b/packages/pwafire/src/pwa/contacts/index.ts
@@ -1,20 +1,34 @@
+import type { ErrorCode } from "../../types/result";
+
 export const contacts = async (
   props: string[],
   options?: {
     multiple: boolean;
   },
-) => {
+): Promise<{
+  ok: boolean;
+  message: string;
+  contacts?: unknown[];
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("contacts" in navigator && "ContactsManager" in window) {
-      const contacts = await (navigator.contacts as any).select(props, options);
-      return { ok: true, message: "Selected", contacts };
-    } else {
-      return { ok: false, message: "Contacts Picker API not supported" };
+    if (!("contacts" in navigator) || !("ContactsManager" in window)) {
+      return { ok: false, code: "unsupported", message: "Contacts Picker API not supported" };
     }
+    const contacts = await (navigator.contacts as any).select(props, options);
+    return { ok: true, message: "Selected", contacts };
   } catch (error) {
+    let code: ErrorCode = "runtime-error";
+    if (error instanceof DOMException) {
+      if (error.name === "InvalidStateError") code = "gesture-required";
+      else if (error.name === "SecurityError") code = "insecure-context";
+    }
     return {
       ok: false,
+      code,
       message: error instanceof Error ? error.message : "Failed to select contacts",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/content-indexing/index.ts
+++ b/packages/pwafire/src/pwa/content-indexing/index.ts
@@ -1,16 +1,25 @@
-export const contentIndexing = async () => {
+import type { ErrorCode } from "../../types/result";
+
+export const contentIndexing = async (): Promise<{
+  ok: boolean;
+  message: string;
+  index?: unknown;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
     const registration = await navigator.serviceWorker.ready;
     const index = (registration as any).index;
-    if (index) {
-      return { ok: true, message: "Indexed", index };
-    } else {
-      return { ok: false, message: "Content Indexing API not supported" };
+    if (!index) {
+      return { ok: false, code: "unsupported", message: "Content Indexing API not supported" };
     }
+    return { ok: true, message: "Indexed", index };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to access content index",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/files/index.ts
+++ b/packages/pwafire/src/pwa/files/index.ts
@@ -1,6 +1,11 @@
-export const readFiles = async (): Promise<FileResponse> => {
+import type { ErrorCode } from "../../types/result";
+
+type FilesResult = FileResponse & { code?: ErrorCode };
+type CreateResult = CreateFileResponse & { code?: ErrorCode };
+
+export const readFiles = async (): Promise<FilesResult> => {
   if (!navigator.clipboard) {
-    return { ok: false, message: "Clipboard API not supported", files: [] };
+    return { ok: false, code: "unsupported", message: "Clipboard API not supported", files: [] };
   }
 
   try {
@@ -17,20 +22,26 @@ export const readFiles = async (): Promise<FileResponse> => {
 
     return { ok: true, message: "Files read successfully", files };
   } catch (error) {
-    return { ok: false, message: `Failed to read files: ${error}`, files: [] };
+    return {
+      ok: false,
+      code: error instanceof DOMException && error.name === "NotAllowedError" ? "permission-denied" : "runtime-error",
+      message: `Failed to read files: ${error}`,
+      files: [],
+      cause: error,
+    };
   }
 };
 
-export const pickTextFile = async (): Promise<FileResponse> => {
+export const pickTextFile = async (): Promise<FilesResult> => {
   if (!("showOpenFilePicker" in self)) {
-    return { ok: false, message: "File System Access API not supported" };
+    return { ok: false, code: "unsupported", message: "File System Access API not supported" };
   }
   try {
     const [fileHandle] = (await self.showOpenFilePicker()) as any;
     const file = await fileHandle.getFile();
 
     if (!file.type.includes("text")) {
-      return { ok: false, message: "Selected file is not a text file" };
+      return { ok: false, code: "invalid-argument", message: "Selected file is not a text file" };
     }
 
     const contents = await file.text();
@@ -42,15 +53,20 @@ export const pickTextFile = async (): Promise<FileResponse> => {
     };
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
-      return { ok: false, message: "File selection cancelled" };
+      return { ok: false, code: "cancelled", message: "File selection cancelled", cause: error };
     }
-    return { ok: false, message: `Failed to read text file: ${error}` };
+    return {
+      ok: false,
+      code: "runtime-error",
+      message: `Failed to read text file: ${error}`,
+      cause: error,
+    };
   }
 };
 
-export const pickFile = async (options?: FilePickerOptions): Promise<FileResponse> => {
+export const pickFile = async (options?: FilePickerOptions): Promise<FilesResult> => {
   if (!("showOpenFilePicker" in self)) {
-    return { ok: false, message: "File System Access API not supported" };
+    return { ok: false, code: "unsupported", message: "File System Access API not supported" };
   }
 
   try {
@@ -63,9 +79,14 @@ export const pickFile = async (options?: FilePickerOptions): Promise<FileRespons
     };
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
-      return { ok: false, message: "File selection cancelled" };
+      return { ok: false, code: "cancelled", message: "File selection cancelled", cause: error };
     }
-    return { ok: false, message: `Failed to pick file: ${error}` };
+    return {
+      ok: false,
+      code: "runtime-error",
+      message: `Failed to pick file: ${error}`,
+      cause: error,
+    };
   }
 };
 
@@ -80,8 +101,8 @@ export const createFile = async (
       },
     ],
   },
-): Promise<CreateFileResponse> => {
-  if (!("showSaveFilePicker" in self)) return { ok: false, message: "File System Access API not supported" };
+): Promise<CreateResult> => {
+  if (!("showSaveFilePicker" in self)) return { ok: false, code: "unsupported", message: "File System Access API not supported" };
   try {
     return {
       ok: true,
@@ -89,34 +110,50 @@ export const createFile = async (
       handle: await self.showSaveFilePicker(options),
     };
   } catch (error) {
-    return { ok: false, message: `Failed to create file: ${error}` };
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return { ok: false, code: "cancelled", message: "File creation cancelled", cause: error };
+    }
+    return {
+      ok: false,
+      code: "runtime-error",
+      message: `Failed to create file: ${error}`,
+      cause: error,
+    };
   }
 };
 
 export const writeFile = async (
   handle: FileSystemFileHandle,
   contents: string | BufferSource | Blob,
-): Promise<FileResponse> => {
-  if (!("showSaveFilePicker" in self)) return { ok: false, message: "File System Access API not supported" };
+): Promise<FilesResult> => {
+  if (!("showSaveFilePicker" in self)) return { ok: false, code: "unsupported", message: "File System Access API not supported" };
   try {
     const writable = await handle.createWritable();
     await writable.write(contents);
     await writable.close();
     return { ok: true, message: "Written to file successfully" };
   } catch (error) {
-    return { ok: false, message: `Failed to write to file: ${error}` };
+    return {
+      ok: false,
+      code: "runtime-error",
+      message: `Failed to write to file: ${error}`,
+      cause: error,
+    };
   }
 };
 
-export const writeUrlToFile = async (handle: FileSystemFileHandle, url: string) => {
-  if (!("showSaveFilePicker" in self)) return { ok: false, message: "File System Access API not supported" };
+export const writeUrlToFile = async (
+  handle: FileSystemFileHandle,
+  url: string,
+): Promise<FilesResult> => {
+  if (!("showSaveFilePicker" in self)) return { ok: false, code: "unsupported", message: "File System Access API not supported" };
   try {
     const writable = await handle.createWritable();
     try {
       const response = await fetch(url);
       if (!response.body) {
         await writable.abort();
-        return { ok: false, message: "Response body is null" };
+        return { ok: false, code: "runtime-error", message: "Response body is null" };
       }
       await response.body.pipeTo(writable);
     } catch (error) {
@@ -125,6 +162,11 @@ export const writeUrlToFile = async (handle: FileSystemFileHandle, url: string) 
     }
     return { ok: true, message: "URL written to file successfully" };
   } catch (error) {
-    return { ok: false, message: `Failed to write URL to file: ${error}` };
+    return {
+      ok: false,
+      code: "runtime-error",
+      message: `Failed to write URL to file: ${error}`,
+      cause: error,
+    };
   }
 };

--- a/packages/pwafire/src/pwa/fonts/index.ts
+++ b/packages/pwafire/src/pwa/fonts/index.ts
@@ -1,16 +1,27 @@
-export const accessFonts = async (config?: { postscriptNames?: string[]; sfnt?: boolean }) => {
+import type { ErrorCode } from "../../types/result";
+
+export const accessFonts = async (
+  config?: { postscriptNames?: string[]; sfnt?: boolean },
+): Promise<{
+  ok: boolean;
+  message: string;
+  fonts: FontData[];
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("queryLocalFonts" in window) {
-      const fonts = await window.queryLocalFonts(config);
-      return { ok: true, message: "Fonts", fonts };
-    } else {
-      return { ok: false, message: "Font Access API not supported", fonts: [] };
+    if (!("queryLocalFonts" in window)) {
+      return { ok: false, code: "unsupported", message: "Font Access API not supported", fonts: [] };
     }
+    const fonts = (await window.queryLocalFonts(config)) as FontData[];
+    return { ok: true, message: "Fonts", fonts };
   } catch (error) {
     return {
       ok: false,
+      code: error instanceof DOMException && error.name === "NotAllowedError" ? "permission-denied" : "runtime-error",
       message: error instanceof Error ? error.message : "Failed to access fonts",
       fonts: [],
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/fullscreen/index.ts
+++ b/packages/pwafire/src/pwa/fullscreen/index.ts
@@ -1,20 +1,30 @@
-export const fullscreen = async () => {
+import type { ErrorCode } from "../../types/result";
+
+export const fullscreen = async (): Promise<{
+  ok: boolean;
+  message: string;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if (document.fullscreenEnabled) {
-      if (!document.fullscreenElement) {
-        await document.documentElement.requestFullscreen();
-        return { ok: true, message: "Fullscreen" };
-      } else {
-        await document.exitFullscreen();
-        return { ok: true, message: "Exit fullscreen" };
-      }
-    } else {
-      return { ok: false, message: "Fullscreen API not supported" };
+    if (!document.fullscreenEnabled) {
+      return { ok: false, code: "unsupported", message: "Fullscreen API not supported" };
     }
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen();
+      return { ok: true, message: "Fullscreen" };
+    }
+    await document.exitFullscreen();
+    return { ok: true, message: "Exit fullscreen" };
   } catch (error) {
+    let code: ErrorCode = "runtime-error";
+    if (error instanceof TypeError) code = "gesture-required";
+    else if (error instanceof DOMException && error.name === "NotAllowedError") code = "permission-denied";
     return {
       ok: false,
+      code,
       message: error instanceof Error ? error.message : "Failed to toggle fullscreen",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/idle-detection/index.ts
+++ b/packages/pwafire/src/pwa/idle-detection/index.ts
@@ -1,35 +1,46 @@
-export const idleDetection = async (action = "start", callback = () => {}, threshold = 60000) => {
+import type { ErrorCode } from "../../types/result";
+
+export const idleDetection = async (
+  action = "start",
+  callback = () => {},
+  threshold = 60000,
+): Promise<{
+  ok: boolean;
+  message: string;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("IdleDetector" in window) {
-      const state = await IdleDetector.requestPermission();
-      if (state === "granted") {
-        const controller = new AbortController();
-        const signal = controller.signal;
-        const idleDetector = new IdleDetector() as any;
-        idleDetector.addEventListener("change", () => {
-          const userState = idleDetector.userState;
-          if (userState === "idle") callback();
-        });
-        if (action === "start") {
-          await idleDetector.start({
-            threshold: threshold > 60000 ? threshold : 60000,
-            signal,
-          });
-          return { ok: true, message: "Started" };
-        } else {
-          controller.abort();
-          return { ok: true, message: "Aborted" };
-        }
-      } else {
-        return { ok: false, message: "Need to request permission first" };
-      }
+    if (!("IdleDetector" in window)) {
+      return { ok: false, code: "unsupported", message: "Idle Detection API not supported" };
+    }
+    const state = await IdleDetector.requestPermission();
+    if (state !== "granted") {
+      return { ok: false, code: "permission-denied", message: "Need to request permission first" };
+    }
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const idleDetector = new IdleDetector() as any;
+    idleDetector.addEventListener("change", () => {
+      const userState = idleDetector.userState;
+      if (userState === "idle") callback();
+    });
+    if (action === "start") {
+      await idleDetector.start({
+        threshold: threshold > 60000 ? threshold : 60000,
+        signal,
+      });
+      return { ok: true, message: "Started" };
     } else {
-      return { ok: false, message: "Idle Detection API not supported" };
+      controller.abort();
+      return { ok: true, message: "Aborted" };
     }
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to detect idle state",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/install/index.ts
+++ b/packages/pwafire/src/pwa/install/index.ts
@@ -1,3 +1,5 @@
+import type { ErrorCode } from "../../types/result";
+
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
   userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
@@ -6,10 +8,10 @@ interface BeforeInstallPromptEvent extends Event {
 export const install = async (
   type: "before" | "install" | "installed" = "installed",
   callback?: (event: string | BeforeInstallPromptEvent) => void,
-) => {
+): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
   try {
     if (!navigator.serviceWorker) {
-      return { ok: false, message: "Service Worker not supported" };
+      return { ok: false, code: "unsupported", message: "Service Worker not supported" };
     }
 
     const methods = {
@@ -36,12 +38,14 @@ export const install = async (
       case "installed":
         return await methods.checkIfAppInstalled();
       default:
-        return { ok: false, message: "Type can be 'install', 'installed' or 'before'" };
+        return { ok: false, code: "invalid-argument", message: "Type can be 'install', 'installed' or 'before'" };
     }
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to handle install event",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/language-detector/index.ts
+++ b/packages/pwafire/src/pwa/language-detector/index.ts
@@ -1,14 +1,25 @@
+import type { ErrorCode } from "../../types/result";
+
 export const languageDetector = async (
   text: string,
   options?: {
     monitor?: (monitor: CreateMonitor) => void;
   },
-) => {
+): Promise<{
+  ok: boolean;
+  message: string;
+  /** @deprecated Use `code` instead. Will be removed in v7. */
+  status: string;
+  results?: unknown;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
     if (!("LanguageDetector" in self)) {
       return {
         ok: false,
         status: "not-supported",
+        code: "unsupported",
         message: "Language Detector API not supported",
       };
     }
@@ -18,6 +29,7 @@ export const languageDetector = async (
       return {
         ok: false,
         status: "unavailable",
+        code: "unsupported",
         message: "Language Detector API not available",
       };
     }
@@ -26,6 +38,7 @@ export const languageDetector = async (
       return {
         ok: false,
         status: "user-activation-required",
+        code: "gesture-required",
         message: "User activation required",
       };
     }
@@ -48,7 +61,9 @@ export const languageDetector = async (
     return {
       ok: false,
       status: "error",
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to detect language",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/lazy-load/index.ts
+++ b/packages/pwafire/src/pwa/lazy-load/index.ts
@@ -1,3 +1,7 @@
+import type { ErrorCode } from "../../types/result";
+
+type Result = LazyLoadResult & { code?: ErrorCode };
+
 const sanitizeUrl = (url: string): string | null => {
   if (!url) return null;
 
@@ -21,11 +25,12 @@ const sanitizeUrl = (url: string): string | null => {
   return trimmedUrl.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 };
 
-export const loadImage = async (element: string, options: ImageOptions = {}): Promise<LazyLoadResult> => {
+export const loadImage = async (element: string, options: ImageOptions = {}): Promise<Result> => {
   try {
     if (!("IntersectionObserver" in window)) {
       return {
         ok: false,
+        code: "unsupported",
         message: "Intersection Observer API not supported",
       };
     }
@@ -35,7 +40,7 @@ export const loadImage = async (element: string, options: ImageOptions = {}): Pr
     const elements = Array.from(document.querySelectorAll(element));
 
     if (!elements.length) {
-      return { ok: false, message: "No elements found" };
+      return { ok: false, code: "invalid-argument", message: "No elements found" };
     }
 
     if (placeholder) {
@@ -73,16 +78,19 @@ export const loadImage = async (element: string, options: ImageOptions = {}): Pr
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to set up lazy loading for images",
+      cause: error,
     };
   }
 };
 
-export const loadBackground = async (element: string, options: BackgroundOptions = {}): Promise<LazyLoadResult> => {
+export const loadBackground = async (element: string, options: BackgroundOptions = {}): Promise<Result> => {
   try {
     if (!("IntersectionObserver" in window)) {
       return {
         ok: false,
+        code: "unsupported",
         message: "Intersection Observer API not supported",
       };
     }
@@ -92,7 +100,7 @@ export const loadBackground = async (element: string, options: BackgroundOptions
     const elements = Array.from(document.querySelectorAll(element));
 
     if (!elements.length) {
-      return { ok: false, message: "No elements found" };
+      return { ok: false, code: "invalid-argument", message: "No elements found" };
     }
 
     if (placeholder) {
@@ -142,16 +150,19 @@ export const loadBackground = async (element: string, options: BackgroundOptions
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to set up lazy loading for backgrounds",
+      cause: error,
     };
   }
 };
 
-export const loadOnScroll = async (element: string, options: ScrollOptions = {}): Promise<LazyLoadResult> => {
+export const loadOnScroll = async (element: string, options: ScrollOptions = {}): Promise<Result> => {
   try {
     if (!("IntersectionObserver" in window)) {
       return {
         ok: false,
+        code: "unsupported",
         message: "Intersection Observer API not supported",
       };
     }
@@ -161,7 +172,7 @@ export const loadOnScroll = async (element: string, options: ScrollOptions = {})
     const elements = Array.from(document.querySelectorAll(element));
 
     if (!elements.length) {
-      return { ok: false, message: "No elements found" };
+      return { ok: false, code: "invalid-argument", message: "No elements found" };
     }
 
     if (style !== "none" && !document.getElementById("pwafire-lazy-styles")) {
@@ -217,16 +228,19 @@ export const loadOnScroll = async (element: string, options: ScrollOptions = {})
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to set up scroll reveal",
+      cause: error,
     };
   }
 };
 
-export const lazyLoad = async (options?: InitOptions): Promise<LazyLoadResult> => {
+export const lazyLoad = async (options?: InitOptions): Promise<Result> => {
   try {
     if (!("IntersectionObserver" in window)) {
       return {
         ok: false,
+        code: "unsupported",
         message: "Intersection Observer API not supported",
       };
     }
@@ -257,7 +271,7 @@ export const lazyLoad = async (options?: InitOptions): Promise<LazyLoadResult> =
     }
 
     if (!promises.length) {
-      return { ok: false, message: "No elements found to lazy load" };
+      return { ok: false, code: "invalid-argument", message: "No elements found to lazy load" };
     }
 
     await Promise.all(promises);
@@ -265,7 +279,9 @@ export const lazyLoad = async (options?: InitOptions): Promise<LazyLoadResult> =
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to initialize lazy loading",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/notification/index.ts
+++ b/packages/pwafire/src/pwa/notification/index.ts
@@ -1,3 +1,5 @@
+import type { ErrorCode } from "../../types/result";
+
 export const notification = async (data: {
   title: string;
   options: {
@@ -20,13 +22,21 @@ export const notification = async (data: {
       placeholder?: string;
     }[];
   };
-}) => {
+}): Promise<{
+  ok: boolean;
+  message: string;
+  /** @deprecated Use `code` instead. Will be removed in v7. */
+  status: string;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   const { title, options } = data;
   try {
     if (!("Notification" in window)) {
       return {
         ok: false,
         status: "not-supported",
+        code: "unsupported",
         message: "Notification API not supported",
       };
     }
@@ -37,6 +47,7 @@ export const notification = async (data: {
       return {
         ok: false,
         status: "permission-denied",
+        code: "permission-denied",
         message: "Notification permission denied",
       };
     }
@@ -63,13 +74,16 @@ export const notification = async (data: {
     return {
       ok: false,
       status: "permission-default",
+      code: "permission-dismissed",
       message: "Notification permission not granted",
     };
   } catch (error) {
     return {
       ok: false,
       status: "error",
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to send notification",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/passkey/index.ts
+++ b/packages/pwafire/src/pwa/passkey/index.ts
@@ -1,19 +1,27 @@
+import type { ErrorCode } from "../../types/result";
+
 type ParseCreationResult = {
   ok: boolean;
   message: string;
   options?: PublicKeyCredentialCreationOptions;
+  code?: ErrorCode;
+  cause?: unknown;
 };
 
 type ParseRequestResult = {
   ok: boolean;
   message: string;
   options?: PublicKeyCredentialRequestOptions;
+  code?: ErrorCode;
+  cause?: unknown;
 };
 
 type PasskeyResult = {
   ok: boolean;
   message: string;
   credential?: PublicKeyCredential;
+  code?: ErrorCode;
+  cause?: unknown;
 };
 
 const getPubKey = (): unknown =>
@@ -27,19 +35,32 @@ const getOrCreateSignal = (): AbortSignal => {
   return passkeyAbortController.signal;
 };
 
+type PasskeyError = { code: ErrorCode; message: string };
+
+const passkeyError = (error: unknown, fallbackMessage: string): PasskeyError => {
+  if (error instanceof Error) {
+    if (error.name === "NotAllowedError") return { code: "cancelled", message: "User cancelled" };
+    if (error.name === "AbortError") return { code: "cancelled", message: "Operation aborted" };
+    if (error.name === "InvalidStateError") return { code: "invalid-argument", message: error.message };
+  }
+  return { code: "runtime-error", message: error instanceof Error ? error.message : fallbackMessage };
+};
+
 const parseCreationOptions = (json: Record<string, unknown>): ParseCreationResult => {
   try {
     const PubKey = getPubKey();
     if (!PubKey || typeof (PubKey as { parseCreationOptionsFromJSON?: (arg: Record<string, unknown>) => PublicKeyCredentialCreationOptions }).parseCreationOptionsFromJSON !== "function") {
-      return { ok: false, message: "Passkey API not supported", options: undefined };
+      return { ok: false, code: "unsupported", message: "Passkey API not supported", options: undefined };
     }
     const options = (PubKey as { parseCreationOptionsFromJSON: (arg: Record<string, unknown>) => PublicKeyCredentialCreationOptions }).parseCreationOptionsFromJSON(json);
     return { ok: true, message: "OK", options };
   } catch (error) {
     return {
       ok: false,
+      code: "invalid-argument",
       message: error instanceof Error ? error.message : "Failed to parse creation options",
       options: undefined,
+      cause: error,
     };
   }
 };
@@ -48,15 +69,17 @@ const parseRequestOptions = (json: Record<string, unknown>): ParseRequestResult 
   try {
     const PubKey = getPubKey();
     if (!PubKey || typeof (PubKey as { parseRequestOptionsFromJSON?: (arg: Record<string, unknown>) => PublicKeyCredentialRequestOptions }).parseRequestOptionsFromJSON !== "function") {
-      return { ok: false, message: "Passkey API not supported", options: undefined };
+      return { ok: false, code: "unsupported", message: "Passkey API not supported", options: undefined };
     }
     const options = (PubKey as { parseRequestOptionsFromJSON: (arg: Record<string, unknown>) => PublicKeyCredentialRequestOptions }).parseRequestOptionsFromJSON(json);
     return { ok: true, message: "OK", options };
   } catch (error) {
     return {
       ok: false,
+      code: "invalid-argument",
       message: error instanceof Error ? error.message : "Failed to parse request options",
       options: undefined,
+      cause: error,
     };
   }
 };
@@ -64,64 +87,50 @@ const parseRequestOptions = (json: Record<string, unknown>): ParseRequestResult 
 const create = async (options: PublicKeyCredentialCreationOptions): Promise<PasskeyResult> => {
   try {
     if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
-      return { ok: false, message: "Passkey API not supported" };
+      return { ok: false, code: "unsupported", message: "Passkey API not supported" };
     }
     const credential = (await navigator.credentials.create({
       publicKey: options,
       signal: getOrCreateSignal(),
     })) as PublicKeyCredential | null;
     if (!credential) {
-      return { ok: false, message: "Failed to create passkey" };
+      return { ok: false, code: "runtime-error", message: "Failed to create passkey" };
     }
     return { ok: true, message: "Passkey created", credential };
   } catch (error) {
+    // InvalidStateError on create() means "this credential already exists" —
+    // treated as success since the desired end state is reached.
     if (error instanceof Error && error.name === "InvalidStateError") {
       return { ok: true, message: "Passkey already exists" };
     }
-    if (error instanceof Error && error.name === "NotAllowedError") {
-      return { ok: false, message: "User cancelled" };
-    }
-    if (error instanceof Error && error.name === "AbortError") {
-      return { ok: false, message: "Operation aborted" };
-    }
-    return {
-      ok: false,
-      message: error instanceof Error ? error.message : "Failed to create passkey",
-    };
+    const { code, message } = passkeyError(error, "Failed to create passkey");
+    return { ok: false, code, message, cause: error };
   }
 };
 
 const get = async (options: PublicKeyCredentialRequestOptions): Promise<PasskeyResult> => {
   try {
     if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
-      return { ok: false, message: "Passkey API not supported" };
+      return { ok: false, code: "unsupported", message: "Passkey API not supported" };
     }
     const credential = (await navigator.credentials.get({
       publicKey: options,
       signal: getOrCreateSignal(),
     })) as PublicKeyCredential | null;
     if (!credential) {
-      return { ok: false, message: "Failed to authenticate" };
+      return { ok: false, code: "runtime-error", message: "Failed to authenticate" };
     }
     return { ok: true, message: "Authenticated", credential };
   } catch (error) {
-    if (error instanceof Error && error.name === "NotAllowedError") {
-      return { ok: false, message: "User cancelled" };
-    }
-    if (error instanceof Error && error.name === "AbortError") {
-      return { ok: false, message: "Operation aborted" };
-    }
-    return {
-      ok: false,
-      message: error instanceof Error ? error.message : "Failed to authenticate",
-    };
+    const { code, message } = passkeyError(error, "Failed to authenticate");
+    return { ok: false, code, message, cause: error };
   }
 };
 
 const getConditional = async (options: PublicKeyCredentialRequestOptions): Promise<PasskeyResult> => {
   try {
     if (!("PublicKeyCredential" in window) || !("credentials" in navigator)) {
-      return { ok: false, message: "Passkey API not supported" };
+      return { ok: false, code: "unsupported", message: "Passkey API not supported" };
     }
     const credential = (await navigator.credentials.get({
       publicKey: options,
@@ -129,35 +138,32 @@ const getConditional = async (options: PublicKeyCredentialRequestOptions): Promi
       signal: getOrCreateSignal(),
     })) as PublicKeyCredential | null;
     if (!credential) {
-      return { ok: false, message: "Failed to authenticate" };
+      return { ok: false, code: "runtime-error", message: "Failed to authenticate" };
     }
     return { ok: true, message: "Authenticated", credential };
   } catch (error) {
-    if (error instanceof Error && error.name === "NotAllowedError") {
-      return { ok: false, message: "User cancelled" };
-    }
-    if (error instanceof Error && error.name === "AbortError") {
-      return { ok: false, message: "Operation aborted" };
-    }
-    return {
-      ok: false,
-      message: error instanceof Error ? error.message : "Failed to authenticate",
-    };
+    const { code, message } = passkeyError(error, "Failed to authenticate");
+    return { ok: false, code, message, cause: error };
   }
 };
 
-const signalUnknown = async (rpId: string, credentialId: string): Promise<{ ok: boolean; message: string }> => {
+const signalUnknown = async (
+  rpId: string,
+  credentialId: string,
+): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
   try {
     const PubKey = getPubKey();
     if (!PubKey || typeof (PubKey as { signalUnknownCredential?: (arg: { rpId: string; credentialId: string }) => Promise<void> }).signalUnknownCredential !== "function") {
-      return { ok: false, message: "Signal API not supported" };
+      return { ok: false, code: "unsupported", message: "Signal API not supported" };
     }
     await (PubKey as { signalUnknownCredential: (arg: { rpId: string; credentialId: string }) => Promise<void> }).signalUnknownCredential({ rpId, credentialId });
     return { ok: true, message: "Signal sent" };
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to signal unknown credential",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/payment/index.ts
+++ b/packages/pwafire/src/pwa/payment/index.ts
@@ -1,3 +1,5 @@
+import type { ErrorCode } from "../../types/result";
+
 export type PaymentRequestInput = {
   methodData: PaymentMethodData[];
   details: PaymentDetailsInit;
@@ -7,19 +9,26 @@ export type PaymentRequestInput = {
 export const payment = async (
   input: PaymentRequestInput,
   onApprove: (response: PaymentResponse) => boolean | Promise<boolean>,
-) => {
+): Promise<{
+  ok: boolean;
+  message: string;
+  methodName?: string;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
     if (typeof window.PaymentRequest === "undefined") {
-      return { ok: false, message: "Payment Request API not supported" };
+      return { ok: false, code: "unsupported", message: "Payment Request API not supported" };
     }
     if (!window.isSecureContext) {
       return {
         ok: false,
+        code: "insecure-context",
         message: "Payment Request API requires a secure context (HTTPS)",
       };
     }
     if (navigator.userActivation && !navigator.userActivation.isActive) {
-      return { ok: false, message: "User activation required" };
+      return { ok: false, code: "gesture-required", message: "User activation required" };
     }
 
     const request = new PaymentRequest(input.methodData, input.details, input.options);
@@ -36,7 +45,9 @@ export const payment = async (
       }
       return {
         ok: false,
+        code: "runtime-error",
         message: err instanceof Error ? err.message : "Failed to process payment",
+        cause: err,
       };
     }
 
@@ -45,8 +56,10 @@ export const payment = async (
     } catch (err) {
       return {
         ok: false,
+        code: "runtime-error",
         message: err instanceof Error ? err.message : "Failed to complete payment",
         methodName: response.methodName,
+        cause: err,
       };
     }
 
@@ -54,6 +67,7 @@ export const payment = async (
     if (!approved) {
       return {
         ok: false,
+        code: "cancelled",
         message: "Payment was not completed",
         methodName,
       };
@@ -66,18 +80,22 @@ export const payment = async (
     };
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
-      return { ok: false, message: "Payment cancelled" };
+      return { ok: false, code: "cancelled", message: "Payment cancelled", cause: error };
     }
     if (error instanceof DOMException && error.name === "NotSupportedError") {
       return {
         ok: false,
+        code: "unsupported",
         message:
           "Payment method not supported or no payment app available; install a payment handler or use another method",
+        cause: error,
       };
     }
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to process payment",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/screen/index.ts
+++ b/packages/pwafire/src/pwa/screen/index.ts
@@ -1,3 +1,5 @@
+import type { ErrorCode } from "../../types/result";
+
 export const screenShare = async (config: {
   video: { displaySurface: "browser" | "monitor" | "window" } | boolean;
   monitorTypeSurfaces?: "exclude" | "include";
@@ -5,16 +7,22 @@ export const screenShare = async (config: {
   selfBrowserSurface?: "include" | "exclude";
   audio?: boolean;
   systemAudio: "exclude" | "include";
-}) => {
+}): Promise<{
+  ok: boolean;
+  message: string;
+  stream: MediaStream | null;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
     if (!navigator.mediaDevices || !("getDisplayMedia" in navigator.mediaDevices)) {
       return {
         ok: false,
+        code: "unsupported",
         message: "Screen sharing is not supported in this browser",
         stream: null,
       };
     }
-
     const stream = await navigator.mediaDevices.getDisplayMedia(config as DisplayMediaStreamOptions);
     return {
       ok: true,
@@ -22,28 +30,42 @@ export const screenShare = async (config: {
       stream,
     };
   } catch (error) {
+    let code: ErrorCode = "runtime-error";
+    if (error instanceof DOMException) {
+      if (error.name === "NotAllowedError") code = "permission-denied";
+      else if (error.name === "AbortError") code = "cancelled";
+    }
     return {
       ok: false,
+      code,
       message: error instanceof Error ? error.message : "Failed to start screen sharing",
       stream: null,
+      cause: error,
     };
   }
 };
 
 export const webPIP = async (
-  callback?: (data: { ok: boolean; message: string; window: Window | null }) => void,
+  callback?: (data: { ok: boolean; message: string; window: Window | null; code?: ErrorCode }) => void,
   config: {
     height?: number;
     width?: number;
     disallowReturnToOpener?: boolean;
   } = {},
-) => {
+): Promise<{
+  ok: boolean;
+  message: string;
+  window: Window | null;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
     const pipButton = document.getElementById("pip-button") as HTMLElement;
     const player = document.getElementById("pip-player") as HTMLElement;
     if (!pipButton || !player) {
       return {
         ok: false,
+        code: "invalid-argument",
         message: "No player or button found.",
         window: null,
       };
@@ -60,7 +82,12 @@ export const webPIP = async (
         if (callback) callback({ ok: true, window: pipWindow, message: "Picture in Picture mode enabled." });
       } else {
         if (callback)
-          callback({ ok: false, window: null, message: "Picture in Picture is not supported in this browser." });
+          callback({
+            ok: false,
+            code: "unsupported",
+            window: null,
+            message: "Picture in Picture is not supported in this browser.",
+          });
       }
     });
 
@@ -72,8 +99,10 @@ export const webPIP = async (
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       window: null,
       message: error instanceof Error ? error.message : "Failed to setup Picture in Picture",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/summarizer/index.ts
+++ b/packages/pwafire/src/pwa/summarizer/index.ts
@@ -1,11 +1,33 @@
+import type { ErrorCode } from "../../types/result";
+
 type SummarizerOptions = SummarizerCreateOptions & { context?: string };
 
-export const summarizer = async (text: string, options?: SummarizerOptions) => {
+type SummarizerResult = {
+  ok: boolean;
+  message: string;
+  /** @deprecated Use `code` instead. Will be removed in v7. */
+  status: string;
+  summary?: string;
+  code?: ErrorCode;
+  cause?: unknown;
+};
+
+type SummarizerStreamResult = {
+  ok: boolean;
+  message: string;
+  /** @deprecated Use `code` instead. Will be removed in v7. */
+  status: string;
+  code?: ErrorCode;
+  cause?: unknown;
+};
+
+export const summarizer = async (text: string, options?: SummarizerOptions): Promise<SummarizerResult> => {
   try {
     if (!("Summarizer" in self)) {
       return {
         ok: false,
         status: "not-supported",
+        code: "unsupported",
         message: "Summarizer API not supported",
       };
     }
@@ -15,6 +37,7 @@ export const summarizer = async (text: string, options?: SummarizerOptions) => {
       return {
         ok: false,
         status: "unavailable",
+        code: "unsupported",
         message: "Summarizer API not available on this device",
       };
     }
@@ -23,6 +46,7 @@ export const summarizer = async (text: string, options?: SummarizerOptions) => {
       return {
         ok: false,
         status: "user-activation-required",
+        code: "gesture-required",
         message: "User activation required",
       };
     }
@@ -44,7 +68,9 @@ export const summarizer = async (text: string, options?: SummarizerOptions) => {
     return {
       ok: false,
       status: "error",
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to summarize",
+      cause: error,
     };
   }
 };
@@ -53,12 +79,13 @@ export const summarizerStream = async (
   text: string,
   callback: (chunk: string) => void,
   options?: SummarizerOptions,
-) => {
+): Promise<SummarizerStreamResult> => {
   try {
     if (!("Summarizer" in self)) {
       return {
         ok: false,
         status: "not-supported",
+        code: "unsupported",
         message: "Summarizer API not supported",
       };
     }
@@ -68,6 +95,7 @@ export const summarizerStream = async (
       return {
         ok: false,
         status: "unavailable",
+        code: "unsupported",
         message: "Summarizer API not available on this device",
       };
     }
@@ -76,6 +104,7 @@ export const summarizerStream = async (
       return {
         ok: false,
         status: "user-activation-required",
+        code: "gesture-required",
         message: "User activation required",
       };
     }
@@ -107,7 +136,9 @@ export const summarizerStream = async (
     return {
       ok: false,
       status: "error",
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to summarize stream",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/translator/index.ts
+++ b/packages/pwafire/src/pwa/translator/index.ts
@@ -1,15 +1,28 @@
+import type { ErrorCode } from "../../types/result";
+
+type TranslatorResult = {
+  ok: boolean;
+  message: string;
+  /** @deprecated Use `code` instead. Will be removed in v7. */
+  status: string;
+  translation?: string;
+  code?: ErrorCode;
+  cause?: unknown;
+};
+
 export const translator = async (
   text: string,
   options: {
     sourceLanguage: string;
     targetLanguage: string;
   },
-) => {
+): Promise<TranslatorResult> => {
   try {
     if (!("Translator" in self)) {
       return {
         ok: false,
         status: "not-supported",
+        code: "unsupported",
         message: "Translator API not supported",
       };
     }
@@ -19,6 +32,7 @@ export const translator = async (
       return {
         ok: false,
         status: "unavailable",
+        code: "unsupported",
         message: "Translator API not available for this language pair",
       };
     }
@@ -27,6 +41,7 @@ export const translator = async (
       return {
         ok: false,
         status: "user-activation-required",
+        code: "gesture-required",
         message: "User activation required",
       };
     }
@@ -49,7 +64,9 @@ export const translator = async (
     return {
       ok: false,
       status: "error",
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to translate",
+      cause: error,
     };
   }
 };
@@ -61,12 +78,13 @@ export const translatorStream = async (
     sourceLanguage: string;
     targetLanguage: string;
   },
-) => {
+): Promise<TranslatorResult> => {
   try {
     if (!("Translator" in self)) {
       return {
         ok: false,
         status: "not-supported",
+        code: "unsupported",
         message: "Translator API not supported",
       };
     }
@@ -76,6 +94,7 @@ export const translatorStream = async (
       return {
         ok: false,
         status: "unavailable",
+        code: "unsupported",
         message: "Translator API not available for this language pair",
       };
     }
@@ -84,6 +103,7 @@ export const translatorStream = async (
       return {
         ok: false,
         status: "user-activation-required",
+        code: "gesture-required",
         message: "User activation required",
       };
     }
@@ -111,7 +131,9 @@ export const translatorStream = async (
     return {
       ok: false,
       status: "error",
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to translate",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/visibility/index.ts
+++ b/packages/pwafire/src/pwa/visibility/index.ts
@@ -1,12 +1,22 @@
+import type { ErrorCode } from "../../types/result";
+
 const noopListen = (_cb: (state: DocumentVisibilityState) => void) => ({
   unlisten: () => {},
 });
 
-export const visibility = () => {
+export const visibility = (): {
+  ok: boolean;
+  message: string;
+  state: DocumentVisibilityState | null;
+  onlisten: typeof noopListen;
+  code?: ErrorCode;
+  cause?: unknown;
+} => {
   try {
     if (!document.visibilityState) {
       return {
         ok: false,
+        code: "unsupported",
         message: "Visibility API not supported",
         state: null,
         onlisten: noopListen,
@@ -30,14 +40,22 @@ export const visibility = () => {
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to check visibility",
       state: null,
       onlisten: noopListen,
+      cause: error,
     };
   }
 };
 
-export const displayMode = () => {
+export const displayMode = (): {
+  ok: boolean;
+  message: string;
+  mode: "standalone" | "minimal-ui" | "fullscreen" | "browser-tab";
+  code?: ErrorCode;
+  cause?: unknown;
+} => {
   try {
     const mode = window.matchMedia("(display-mode: standalone)").matches
       ? "standalone"
@@ -55,8 +73,10 @@ export const displayMode = () => {
   } catch (error) {
     return {
       ok: false,
+      code: "runtime-error",
       message: error instanceof Error ? error.message : "Failed to detect display mode",
       mode: "browser-tab",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/wake-lock/index.ts
+++ b/packages/pwafire/src/pwa/wake-lock/index.ts
@@ -1,15 +1,24 @@
-export const wakeLock = async () => {
+import type { ErrorCode } from "../../types/result";
+
+export const wakeLock = async (): Promise<{
+  ok: boolean;
+  message: string;
+  wakeLock?: WakeLockSentinel;
+  code?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
-    if ("wakeLock" in navigator) {
-      const wakeLock = await navigator.wakeLock.request("screen");
-      return { ok: true, message: "Wake lock", wakeLock };
-    } else {
-      return { ok: false, message: "Wake Lock API not supported" };
+    if (!("wakeLock" in navigator)) {
+      return { ok: false, code: "unsupported", message: "Wake Lock API not supported" };
     }
+    const wakeLock = await navigator.wakeLock.request("screen");
+    return { ok: true, message: "Wake lock", wakeLock };
   } catch (error) {
     return {
       ok: false,
+      code: error instanceof DOMException && error.name === "NotAllowedError" ? "permission-denied" : "runtime-error",
       message: error instanceof Error ? error.message : "Failed to acquire wake lock",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/web-otp/index.ts
+++ b/packages/pwafire/src/pwa/web-otp/index.ts
@@ -1,17 +1,17 @@
 import type { ErrorCode } from "../../types/result";
 
-// `code` is the OTP value (back-compat); the v6.5 error discriminator
-// is exposed as `errorCode` here to avoid colliding with it.
 export const webOtp = async (): Promise<{
   ok: boolean;
   message: string;
+  /** @deprecated Use `otpCode`. In v7 this field will be removed and `code` will become the `ErrorCode` discriminator like every other pwafire API. */
   code: string | null;
+  otpCode: string | null;
   errorCode?: ErrorCode;
   cause?: unknown;
 }> => {
   try {
     if (!("OTPCredential" in window)) {
-      return { ok: false, errorCode: "unsupported", message: "Web OTP API not supported", code: null };
+      return { ok: false, errorCode: "unsupported", message: "Web OTP API not supported", code: null, otpCode: null };
     }
 
     const input = document.querySelector('input[autocomplete="one-time-code"]');
@@ -21,6 +21,7 @@ export const webOtp = async (): Promise<{
         errorCode: "invalid-argument",
         message: "No input with autocomplete='one-time-code' found",
         code: null,
+        otpCode: null,
       };
     }
 
@@ -41,6 +42,7 @@ export const webOtp = async (): Promise<{
       ok: true,
       message: "OTP received",
       code: otp.code,
+      otpCode: otp.code,
     };
   } catch (error) {
     let errorCode: ErrorCode = "runtime-error";
@@ -50,6 +52,7 @@ export const webOtp = async (): Promise<{
       errorCode,
       message: error instanceof Error ? error.message : "Failed to get OTP",
       code: null,
+      otpCode: null,
       cause: error,
     };
   }

--- a/packages/pwafire/src/pwa/web-otp/index.ts
+++ b/packages/pwafire/src/pwa/web-otp/index.ts
@@ -1,13 +1,24 @@
-export const webOtp = async () => {
+import type { ErrorCode } from "../../types/result";
+
+// `code` is the OTP value (back-compat); the v6.5 error discriminator
+// is exposed as `errorCode` here to avoid colliding with it.
+export const webOtp = async (): Promise<{
+  ok: boolean;
+  message: string;
+  code: string | null;
+  errorCode?: ErrorCode;
+  cause?: unknown;
+}> => {
   try {
     if (!("OTPCredential" in window)) {
-      return { ok: false, message: "Web OTP API not supported", code: null };
+      return { ok: false, errorCode: "unsupported", message: "Web OTP API not supported", code: null };
     }
 
     const input = document.querySelector('input[autocomplete="one-time-code"]');
     if (!input) {
       return {
         ok: false,
+        errorCode: "invalid-argument",
         message: "No input with autocomplete='one-time-code' found",
         code: null,
       };
@@ -32,10 +43,14 @@ export const webOtp = async () => {
       code: otp.code,
     };
   } catch (error) {
+    let errorCode: ErrorCode = "runtime-error";
+    if (error instanceof DOMException && error.name === "AbortError") errorCode = "cancelled";
     return {
       ok: false,
+      errorCode,
       message: error instanceof Error ? error.message : "Failed to get OTP",
       code: null,
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/pwa/web-share/index.ts
+++ b/packages/pwafire/src/pwa/web-share/index.ts
@@ -1,19 +1,28 @@
-export const webShare = async (data: ShareData) => {
+import type { ErrorCode } from "../../types/result";
+
+export const webShare = async (
+  data: ShareData,
+): Promise<{ ok: boolean; message: string; code?: ErrorCode; cause?: unknown }> => {
   try {
-    if ("canShare" in navigator && "share" in navigator) {
-      if (navigator.canShare(data)) {
-        await navigator.share(data);
-        return { ok: true, message: "Shared" };
-      } else {
-        return { ok: false, message: "Cannot share this data" };
-      }
-    } else {
-      return { ok: false, message: "Web Share API not supported" };
+    if (!("canShare" in navigator) || !("share" in navigator)) {
+      return { ok: false, code: "unsupported", message: "Web Share API not supported" };
     }
+    if (!navigator.canShare(data)) {
+      return { ok: false, code: "invalid-argument", message: "Cannot share this data" };
+    }
+    await navigator.share(data);
+    return { ok: true, message: "Shared" };
   } catch (error) {
+    let code: ErrorCode = "runtime-error";
+    if (error instanceof DOMException) {
+      if (error.name === "AbortError") code = "cancelled";
+      else if (error.name === "NotAllowedError") code = "permission-denied";
+    }
     return {
       ok: false,
+      code,
       message: error instanceof Error ? error.message : "Failed to share",
+      cause: error,
     };
   }
 };

--- a/packages/pwafire/src/types/capability.ts
+++ b/packages/pwafire/src/types/capability.ts
@@ -1,0 +1,36 @@
+/**
+ * Reason a capability is unavailable. Set only when `supported === false`.
+ *
+ * - `no-api`: the API isn't present in this runtime (wrong/old browser).
+ * - `insecure-context`: API exists but page isn't a secure context (HTTPS).
+ * - `no-user-activation`: API exists but requires a recent user gesture.
+ */
+export type CapabilityReason =
+  | "no-api"
+  | "insecure-context"
+  | "no-user-activation";
+
+/**
+ * Structured capability descriptor returned by `pwafire/capability`.
+ *
+ * Unlike `pwafire/check` (which returns plain booleans, retained for
+ * back-compat), this shape carries diagnostic and platform metadata
+ * so apps can progressively enhance and surface helpful errors.
+ *
+ * @since 6.5.0
+ */
+export type Capability = {
+  supported: boolean;
+  /** Why the capability is unavailable. Only set when supported === false. */
+  reason?: CapabilityReason;
+  /** Is the page currently in a secure context (HTTPS or localhost)? */
+  secureContext: boolean;
+  /** Does the API require user activation to invoke? Static metadata. */
+  requiresUserActivation: boolean;
+  /** First stable version per browser engine, when known. */
+  since?: { chrome?: string; safari?: string; firefox?: string };
+  /** Spec URL (WHATWG, W3C, WICG, etc.). */
+  spec?: string;
+  /** MDN reference URL. */
+  mdn?: string;
+};

--- a/packages/pwafire/src/types/capability.ts
+++ b/packages/pwafire/src/types/capability.ts
@@ -1,36 +1,11 @@
-/**
- * Reason a capability is unavailable. Set only when `supported === false`.
- *
- * - `no-api`: the API isn't present in this runtime (wrong/old browser).
- * - `insecure-context`: API exists but page isn't a secure context (HTTPS).
- * - `no-user-activation`: API exists but requires a recent user gesture.
- */
 export type CapabilityReason =
   | "no-api"
   | "insecure-context"
   | "no-user-activation";
 
-/**
- * Structured capability descriptor returned by `pwafire/capability`.
- *
- * Unlike `pwafire/check` (which returns plain booleans, retained for
- * back-compat), this shape carries diagnostic and platform metadata
- * so apps can progressively enhance and surface helpful errors.
- *
- * @since 6.5.0
- */
 export type Capability = {
   supported: boolean;
-  /** Why the capability is unavailable. Only set when supported === false. */
   reason?: CapabilityReason;
-  /** Is the page currently in a secure context (HTTPS or localhost)? */
   secureContext: boolean;
-  /** Does the API require user activation to invoke? Static metadata. */
   requiresUserActivation: boolean;
-  /** First stable version per browser engine, when known. */
-  since?: { chrome?: string; safari?: string; firefox?: string };
-  /** Spec URL (WHATWG, W3C, WICG, etc.). */
-  spec?: string;
-  /** MDN reference URL. */
-  mdn?: string;
 };

--- a/packages/pwafire/src/types/files.d.ts
+++ b/packages/pwafire/src/types/files.d.ts
@@ -5,12 +5,16 @@ interface FileResponse {
   files?: File[];
   file?: File;
   contents?: string;
+  code?: string;
+  cause?: unknown;
 }
 
 interface CreateFileResponse {
   ok: boolean;
   message: string;
   handle?: FileSystemFileHandle;
+  code?: string;
+  cause?: unknown;
 }
 
 interface FilePickerOptions {

--- a/packages/pwafire/src/types/lazy-load.d.ts
+++ b/packages/pwafire/src/types/lazy-load.d.ts
@@ -2,6 +2,8 @@
 interface LazyLoadResult {
   ok: boolean;
   message: string;
+  code?: string;
+  cause?: unknown;
 }
 
 interface ImageOptions {

--- a/packages/pwafire/src/types/result.ts
+++ b/packages/pwafire/src/types/result.ts
@@ -1,10 +1,3 @@
-/**
- * Kebab-case discriminator added to every pwafire API result in v6.5+.
- *
- * Existing `{ ok, message }` fields are unchanged — `code` and `cause`
- * are additive, opt-in, and let consumers branch on failure modes
- * without string-matching `message`.
- */
 export type ErrorCode =
   | "unsupported"
   | "insecure-context"
@@ -15,20 +8,9 @@ export type ErrorCode =
   | "invalid-argument"
   | "runtime-error";
 
-/**
- * The v6.5 additive return contract. Every existing field stays; `code`
- * and `cause` are new.
- *
- * Consumers can keep using `r.ok` and `r.message` — the new fields are
- * opt-in for typed branching and richer diagnostics.
- *
- * @since 6.5.0
- */
 export type ResultMeta<C extends ErrorCode = ErrorCode> = {
   ok: boolean;
   message: string;
-  /** Present on every result from v6.5 onward. */
   code?: C;
-  /** Original error preserved in catch blocks for debugging. */
   cause?: unknown;
 };

--- a/packages/pwafire/src/types/result.ts
+++ b/packages/pwafire/src/types/result.ts
@@ -1,0 +1,34 @@
+/**
+ * Kebab-case discriminator added to every pwafire API result in v6.5+.
+ *
+ * Existing `{ ok, message }` fields are unchanged — `code` and `cause`
+ * are additive, opt-in, and let consumers branch on failure modes
+ * without string-matching `message`.
+ */
+export type ErrorCode =
+  | "unsupported"
+  | "insecure-context"
+  | "permission-denied"
+  | "permission-dismissed"
+  | "gesture-required"
+  | "cancelled"
+  | "invalid-argument"
+  | "runtime-error";
+
+/**
+ * The v6.5 additive return contract. Every existing field stays; `code`
+ * and `cause` are new.
+ *
+ * Consumers can keep using `r.ok` and `r.message` — the new fields are
+ * opt-in for typed branching and richer diagnostics.
+ *
+ * @since 6.5.0
+ */
+export type ResultMeta<C extends ErrorCode = ErrorCode> = {
+  ok: boolean;
+  message: string;
+  /** Present on every result from v6.5 onward. */
+  code?: C;
+  /** Original error preserved in catch blocks for debugging. */
+  cause?: unknown;
+};


### PR DESCRIPTION
## Summary

v6.5.0 ships a fully back-compatible DX upgrade:

- **Typed errors on every API.** `{ ok, message, code, cause }` where `code` is a kebab-case `ErrorCode` literal (`"unsupported"`, `"permission-denied"`, `"gesture-required"`, …) and `cause` preserves the original `DOMException`. Branch on `code` instead of `message`-string-matching.
- **`pwafire/capability` subpath.** Returns `{ supported, reason, secureContext, requiresUserActivation }` per API. `reason` distinguishes `"no-api"` / `"insecure-context"` / `"no-user-activation"` so apps can progressively enhance with actionable diagnostics. `pwafire/check` is soft-deprecated (still works; JSDoc points to capability) and removed in v7.
- **Strictly additive.** Every existing field on every result is unchanged. APIs that already exposed `status` (notification, summarizer, translator, language-detector) keep it with `@deprecated Will be removed in v7` JSDoc next to the new `code` mirror.
- **Contract pinned by tests.** `src/pwa/codes.test.ts` has one spec-cited test per `ErrorCode` literal; the v6.5 typed-error shape can't drift without a CI failure.
- **Size-budgeted CI.** `size-limit` with brotli budgets on the most-used entries; gates `verify` and CI.
- **Live demo in the console.** A v6.5 panel in `console/` exercises both subpaths end-to-end against the built artifacts.
- **Bumps to v6.5.0.**

## Changes by commit

| Commit | What |
| --- | --- |
| `bdbefae` | `ErrorCode` union + `ResultMeta<C>` foundation; clipboard/badging as reference shape |
| `e3329c6` | Sweep `code`+`cause` into the other 23 APIs; `DOMException.name` → `ErrorCode` mapping per call site |
| `fa590b6` | `pwafire/capability` (`src/capability/index.ts`), `./capability` export entry, `"browser"` condition added before `"import"` on every entry, web-otp `otpCode` deprecation runway |
| `7f1a941` → `66eeffd` | README "Why pwafire" + matrix added then reverted; existing post-#187 structure is the right altitude |
| `d65bc96` | `size-limit` budgets + CI step + bump to 6.5.0 |
| `01fcb83` | Drop `spec`/`mdn`/`since` from runtime `Capability` shape — docs-shaped bloat. Capability is now `{ supported, reason?, secureContext, requiresUserActivation }`. URLs live in caniuse/MDN, not in the bundle |
| `c0ff301` | `@deprecated` JSDoc on every `pwafire/check` export — superseded by `pwafire/capability` in v7 |
| `e6509b3` | `src/pwa/codes.test.ts` — one spec-cited test per `ErrorCode` literal (8 codes, 8 tests). Fix `check.install` probe to match `capability.install` (was probing the wrong API) |
| `0ef36aa` | Console v6.5 demo panel — capability rows + typed-code branching button, verified live in the dev preview |

## Notable design calls

**`pwafire/capability` is the canonical detection subpath going forward.** It's the platform-fluent name (Project Fugu, Web Capabilities) and carries strictly more information than a boolean — `.supported` is the boolean equivalent, plus `reason`, `secureContext`, `requiresUserActivation`. v6.5 soft-deprecates `pwafire/check` (JSDoc-only, runtime unchanged); v7 removes the subpath. Migration is `check.clipboard()` → `capability.clipboard().supported`.

**Capability `reason` enum mirrors the three real failure modes** in PWA capability detection. Most libraries collapse "API missing" and "API present but insecure context" into one `false` — keeping them apart lets consumers surface a helpful banner instead of a dead button.

**Web-otp is the one place the universal `{ code }` shape doesn't yet land.** The existing payload already used `code` for the OTP value, so v6.5 adds `otpCode` as an additive alias and exposes the discriminator as `errorCode`. In v7 we drop the legacy `code`-as-OTP and rename `errorCode` → `code`. The deprecation note is in JSDoc.

**Per-export JSDoc was dropped in favor of self-documenting types.** Earlier draft had spec-aligned JSDoc on every export; pushed back — well-named identifiers + the typed `code` discriminator do the documenting. JSDoc retained only where it's load-bearing: `@deprecated` on `status` mirrors, `@deprecated` on `check.*`, one inline note in passkey (`InvalidStateError` → `ok: true`), the web-otp naming-collision callout.

**`"browser"` placed before `"import"` in every export entry.** Vite, esbuild (`platform: "browser"`), Webpack, and `tsup` all honor it first. Both conditions currently point at the same `.mjs`; the structure is in place for the day we ship a browser-only bundle.

**Size budgets sit ~30% above current** so they catch regressions without being noisy:

| Entry | Brotli | Limit |
| --- | ---: | ---: |
| `pwafire` (full surface) | 6.53 kB | 10 kB |
| `pwafire/check` | 531 B | 700 B |
| `pwafire/capability` | 843 B | 2.2 kB |
| `pwafire/clipboard` | 417 B | 600 B |
| `pwafire/notification` | 370 B | 500 B |
| `pwafire/passkey` | 741 B | 1 kB |

## Verification

- `npm run -w pwafire verify` green: `sync:exports:check`, lint, build, **28/28 tests** (20 baseline + 8 new `ErrorCode` contract tests), all 6 size budgets pass.
- Console builds clean (`npm run build` in `console/`).
- Console demo verified live in the dev preview: capability rows render with correct `reason` (`no-user-activation` pre-click, `no-api` for unsupported), `demoCopy()` correctly maps Chrome's `NotAllowedError` on the clipboard write to the `permission-denied` branch.
- Branch is rebased on top of `main` (no merge needed; `bdbefae` was authored directly on the #187 merge commit).

## Test plan

- [ ] CI green on this PR (lint, test, build, size, coverage)
- [ ] After merge: tag `pwafire@6.5.0` on `main` and `npm publish -w pwafire`
- [ ] Spot-check on esm.sh: `import { clipboard } from "https://esm.sh/pwafire@6.5/capability"`
- [ ] Open `console.pwafire.org` post-deploy and confirm the v6.5 panel renders + the typed-code button works

## Follow-ups (not in this PR)

- npm provenance + OIDC publish workflow (the item PR #187 explicitly held)
- v7 cleanups:
  - Remove `pwafire/check` subpath
  - Drop `status` from notification/summarizer/translator/language-detector
  - Rename web-otp `errorCode` → `code` and remove the legacy OTP-value `code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)