### PR TITLE
feat(console): improve dark mode contrast, typography scale, and svg icons

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -36,7 +36,20 @@
               rel="noopener"
               class="header-link"
             >
-              📚 Docs
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+              </svg>
+              <span>Docs</span>
             </a>
             <a
               href="https://stackblitz.com/edit/pwafire?file=src%2Findex.ts"
@@ -44,7 +57,19 @@
               rel="noopener"
               class="header-link"
             >
-              ⚡ Playground
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+              </svg>
+              <span>Playground</span>
             </a>
             <a
               href="https://github.com/pwafire/pwafire"
@@ -125,7 +150,7 @@
         <div class="stats-panel">
           <div class="stats-title">v6.5 Capability</div>
           <div id="capability-demo-list"></div>
-          <button onclick="window.demoCopy().then(m => window.logConsole(m, 'info'))" style="margin-top: 8px; width: 100%;">Try copyText (typed code)</button>
+          <button class="action-button secondary" onclick="window.demoCopy().then(m => window.logConsole(m, 'info'))" style="margin-top: 8px;">Try copyText (typed code)</button>
         </div>
 
         <div class="shortcuts-panel">

--- a/console/src/api-configs/index.ts
+++ b/console/src/api-configs/index.ts
@@ -374,15 +374,15 @@ export const apiConfigs: Record<string, ApiConfig> = {
 };
 
 export const apiGroups: Record<string, string[]> = {
-  "🤖 AI": [
+  AI: [
     "summarizer",
     "summarizerStream",
     "translator",
     "translatorStream",
     "languageDetector"
   ],
-  "📋 Clipboard": ["copyText", "readText", "copyImage"],
-  "📁 File System": [
+  Clipboard: ["copyText", "readText", "copyImage"],
+  "File System": [
     "pickFile",
     "pickTextFile",
     "readFiles",
@@ -390,26 +390,26 @@ export const apiGroups: Record<string, string[]> = {
     "writeFile",
     "writeUrlToFile"
   ],
-  "🔔 Notifications": ["notification", "setBadge", "clearBadge"],
-  "🔗 Sharing": ["webShare"],
-  "🖥️ Screen": ["screenShare", "webPIP", "fullscreen"],
-  "⚡ System": [
+  Notifications: ["notification", "setBadge", "clearBadge"],
+  Sharing: ["webShare"],
+  Screen: ["screenShare", "webPIP", "fullscreen"],
+  System: [
     "wakeLock",
     "idleDetection",
     "connectivity",
     "visibility",
     "displayMode"
   ],
-  "🎨 Media": [
+  Media: [
     "barcodeDetector",
     "compressStream",
     "decompressStream",
     "lazyLoad",
     "accessFonts"
   ],
-  "💳 Payment": ["payment"],
-  "👤 User Data": ["contacts", "webOtp"],
-  "🔐 Passkey": ["passkey.create", "passkey.get", "passkey.getConditional"],
-  "📡 Broadcast": ["broadcast.send", "broadcast.listen"],
-  "📦 Other": ["contentIndexing", "install"]
+  Payment: ["payment"],
+  "User Data": ["contacts", "webOtp"],
+  Passkey: ["passkey.create", "passkey.get", "passkey.getConditional"],
+  Broadcast: ["broadcast.send", "broadcast.listen"],
+  Other: ["contentIndexing", "install"]
 };

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -6,20 +6,20 @@
   --color-gray-800: #222;
   --color-gray-700: #333;
   --color-gray-600: #444;
-  --color-gray-500: #666;
-  --color-gray-400: #888;
-  --color-gray-300: #aaa;
+  --color-gray-500: #777;
+  --color-gray-400: #999;
+  --color-gray-300: #bbb;
   --color-gray-200: #ddd;
   --color-white: #fff;
-  --color-accent: pink;
+  --color-accent: #00ff41;
 
-  --font-size-xs: 8px;
-  --font-size-sm: 9px;
-  --font-size-base: 10px;
-  --font-size-md: 11px;
-  --font-size-lg: 12px;
-  --font-size-xl: 13px;
-  --font-size-2xl: 14px;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-base: 13px;
+  --font-size-md: 14px;
+  --font-size-lg: 15px;
+  --font-size-xl: 16px;
+  --font-size-2xl: 18px;
   --font-size-3xl: 24px;
 
   --spacing-xs: 2px;
@@ -108,7 +108,7 @@ body {
   left: 0;
   width: 0%;
   height: 1px;
-  background: linear-gradient(90deg, var(--color-accent), #ff69b4);
+  background: linear-gradient(90deg, var(--color-accent), #00cc33);
   z-index: 10001;
   transition: width 0.3s ease, opacity 0.3s ease;
   opacity: 0;
@@ -255,14 +255,14 @@ body {
 }
 
 .panel-title {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-base);
   margin-bottom: var(--spacing-2xl);
   padding-bottom: var(--spacing-base);
-  border-bottom: var(--border-width-sm) solid var(--color-gray-dark);
-  color: var(--color-gray-500);
+  border-bottom: var(--border-width-sm) solid var(--color-gray-700);
+  color: var(--color-white);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-md);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .feature-item {
@@ -274,35 +274,36 @@ body {
   border-left: var(--border-width-md) solid transparent;
   padding-left: var(--spacing-base);
   transition: all var(--transition-fast);
-  color: var(--color-gray-400);
+  color: var(--color-gray-300);
   text-transform: capitalize;
 }
 
 .feature-item:hover {
-  border-left-color: var(--color-white);
+  border-left-color: var(--color-accent);
   padding-left: var(--spacing-xl);
   color: var(--color-white);
 }
 
 .feature-item.supported {
-  color: var(--color-gray-300);
-}
-
-.feature-item.not-supported {
-  color: var(--color-gray-600);
-}
-
-.feature-status {
-  font-size: var(--font-size-sm);
-  color: var(--color-gray-500);
-}
-
-.feature-status.yes {
   color: var(--color-white);
 }
 
+.feature-item.not-supported {
+  color: var(--color-gray-400);
+}
+
+.feature-status {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: var(--letter-spacing-sm);
+}
+
+.feature-status.yes {
+  color: var(--color-accent);
+}
+
 .feature-status.no {
-  color: var(--color-gray-700);
+  color: var(--color-gray-500);
 }
 
 .test-grid {
@@ -314,20 +315,20 @@ body {
 .test-card {
   background: var(--color-black);
   padding: var(--spacing-xl);
-  border: var(--border-width-sm) solid var(--color-gray-dark);
+  border: var(--border-width-sm) solid var(--color-gray-700);
   transition: all var(--transition-fast);
 }
 
 .test-card:hover {
-  border-color: var(--color-gray-700);
+  border-color: var(--color-gray-500);
   background: var(--color-gray-darkest);
 }
 
 .test-card h3 {
   font-size: var(--font-size-md);
-  font-weight: 400;
+  font-weight: 500;
   margin-bottom: var(--spacing-base);
-  color: var(--color-gray-400);
+  color: var(--color-white);
 }
 
 .demo-reference {
@@ -400,7 +401,7 @@ body {
 .test-card button {
   background: var(--color-black);
   color: var(--color-white);
-  border: var(--border-width-sm) solid var(--color-gray-700);
+  border: var(--border-width-sm) solid var(--color-gray-600);
   padding: var(--spacing-base);
   font-family: inherit;
   font-size: var(--font-size-base);
@@ -410,7 +411,7 @@ body {
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-base);
   margin-bottom: var(--spacing-sm);
-  font-weight: 400;
+  font-weight: 500;
 }
 
 .test-card button:hover:not(:disabled) {
@@ -420,7 +421,7 @@ body {
 }
 
 .test-card button:disabled {
-  opacity: 0.2;
+  opacity: 0.3;
   cursor: not-allowed;
 }
 
@@ -429,7 +430,7 @@ body {
   padding: var(--spacing-base);
   margin-bottom: var(--spacing-base);
   background: var(--color-black);
-  border: var(--border-width-sm) solid var(--color-gray-dark);
+  border: var(--border-width-sm) solid var(--color-gray-600);
   color: var(--color-white);
   font-family: inherit;
   font-size: var(--font-size-base);
@@ -437,11 +438,11 @@ body {
 
 .test-card input:focus {
   outline: none;
-  border-color: var(--color-gray-700);
+  border-color: var(--color-accent);
 }
 
 .test-card input::placeholder {
-  color: var(--color-gray-600);
+  color: var(--color-gray-400);
 }
 
 .result {
@@ -481,20 +482,21 @@ body {
 }
 
 .console-line {
-  color: var(--color-gray-500);
+  color: var(--color-gray-300);
   margin-bottom: var(--spacing-xs);
+  line-height: 1.5;
 }
 
 .console-line.success {
-  color: var(--color-white);
+  color: var(--color-accent);
 }
 
 .console-line.error {
-  color: var(--color-gray-400);
+  color: #ff5555;
 }
 
 .console-line.info {
-  color: var(--color-gray-600);
+  color: #88a8d0;
 }
 
 .action-button {
@@ -502,13 +504,13 @@ body {
   padding: var(--spacing-lg);
   font-family: inherit;
   cursor: pointer;
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-sm);
   width: 100%;
   margin-bottom: var(--spacing-base);
   transition: all var(--transition-fast);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-base);
-  font-weight: 400;
+  font-weight: 500;
 }
 
 .action-button.primary {
@@ -523,38 +525,40 @@ body {
 
 .action-button.secondary {
   border: var(--border-width-sm) solid var(--color-gray-600);
-  color: var(--color-gray-500);
+  color: var(--color-gray-200);
 }
 
 .action-button.secondary:hover {
-  border-color: var(--color-gray-400);
+  border-color: var(--color-white);
   color: var(--color-white);
+  background: var(--color-gray-darker);
 }
 
 .action-button.danger {
-  border: var(--border-width-sm) solid var(--color-gray-700);
-  color: var(--color-gray-600);
+  border: var(--border-width-sm) solid var(--color-gray-600);
+  color: var(--color-gray-300);
 }
 
 .action-button.danger:hover {
-  border-color: var(--color-gray-500);
-  color: var(--color-gray-400);
+  border-color: #ff5555;
+  color: #ff5555;
 }
 
 .stats-panel {
   margin-top: var(--spacing-2xl);
   padding: var(--spacing-xl);
-  border: var(--border-width-sm) solid var(--color-gray-dark);
+  border: var(--border-width-sm) solid var(--color-gray-700);
   font-size: var(--font-size-sm);
-  color: var(--color-gray-500);
+  color: var(--color-gray-300);
 }
 
 .stats-title {
   font-size: var(--font-size-sm);
   margin-bottom: var(--spacing-base);
-  color: var(--color-gray-400);
+  color: var(--color-white);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-base);
+  font-weight: 600;
 }
 
 .stats-panel div span {
@@ -586,26 +590,40 @@ body {
   color: var(--color-white);
 }
 
+.import-reason {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  color: var(--color-gray-400);
+  background: var(--color-gray-darker);
+  padding: 1px 6px;
+  border-radius: var(--border-radius-sm);
+  border: var(--border-width-sm) solid var(--color-gray-700);
+}
+
 .shortcuts-panel {
   margin-top: var(--spacing-2xl);
   padding: var(--spacing-xl);
-  border: var(--border-width-sm) solid var(--color-gray-dark);
+  border: var(--border-width-sm) solid var(--color-gray-700);
   font-size: var(--font-size-sm);
-  color: var(--color-gray-500);
+  color: var(--color-gray-300);
 }
 
 .shortcuts-title {
   font-size: var(--font-size-sm);
   margin-bottom: var(--spacing-base);
-  color: var(--color-gray-400);
+  color: var(--color-white);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-base);
+  font-weight: 600;
 }
 
-.shortcuts-content code {
-  color: var(--color-gray-300);
-  background: var(--color-black);
-  padding: var(--spacing-xs) var(--spacing-sm);
+.shortcuts-panel code {
+  color: var(--color-accent);
+  background: var(--color-gray-darker);
+  border: var(--border-width-sm) solid var(--color-gray-700);
+  padding: 2px 5px;
+  border-radius: var(--border-radius-sm);
+  margin-right: var(--spacing-sm);
 }
 
 .actions-container {
@@ -806,7 +824,7 @@ body {
   margin-bottom: var(--spacing-3xl);
   padding: var(--spacing-xl) var(--spacing-2xl);
   background: var(--color-gray-darker);
-  border-left: var(--border-width-md) solid var(--color-white);
+  border-left: var(--border-width-md) solid var(--color-accent);
 }
 
 .result-error {
@@ -815,16 +833,16 @@ body {
   margin-bottom: var(--spacing-3xl);
   padding: var(--spacing-xl) var(--spacing-2xl);
   background: var(--color-gray-darker);
-  border-left: var(--border-width-md) solid var(--color-gray-500);
+  border-left: var(--border-width-md) solid #ff5555;
 }
 
 .result-info {
-  color: var(--color-gray-400);
+  color: var(--color-gray-200);
   font-size: var(--font-size-xl);
   margin-bottom: var(--spacing-3xl);
   padding: var(--spacing-xl) var(--spacing-2xl);
   background: var(--color-gray-darker);
-  border-left: var(--border-width-md) solid var(--color-gray-600);
+  border-left: var(--border-width-md) solid #88a8d0;
 }
 
 .stream-info {
@@ -1275,14 +1293,33 @@ body {
 /* Test Group Headers */
 .test-group-header {
   grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-base);
   color: var(--color-accent);
   font-size: var(--font-size-md);
-  font-weight: bold;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-md);
   padding: var(--spacing-lg) 0 var(--spacing-base) 0;
   margin-top: var(--spacing-2xl);
   border-bottom: var(--border-width-sm) solid var(--color-gray-700);
+}
+
+.test-group-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-accent);
+}
+
+.test-group-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.test-group-title {
+  display: inline-block;
 }
 
 .test-group-header:first-child {

--- a/console/src/tests/index.ts
+++ b/console/src/tests/index.ts
@@ -413,6 +413,22 @@ const setupStreamModalError = (apiName: string): void => {
   };
 };
 
+const GROUP_ICONS: Record<string, string> = {
+  AI: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="14" x2="23" y2="14"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="14" x2="4" y2="14"/></svg>',
+  Clipboard: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1"/></svg>',
+  "File System": '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>',
+  Notifications: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>',
+  Sharing: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>',
+  Screen: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>',
+  System: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
+  Media: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="2" width="20" height="20" rx="2.18"/><line x1="7" y1="2" x2="7" y2="22"/><line x1="17" y1="2" x2="17" y2="22"/><line x1="2" y1="12" x2="22" y2="12"/></svg>',
+  Payment: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="4" width="22" height="16" rx="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>',
+  "User Data": '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
+  Passkey: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>',
+  Broadcast: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4.93 4.93a10 10 0 0 1 14.14 0"/><path d="M7.76 7.76a6 6 0 0 1 8.48 0"/><circle cx="12" cy="12" r="2"/></svg>',
+  Other: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>'
+};
+
 export const generateTests = (): void => {
   const testGrid = document.getElementById("test-grid");
   if (!testGrid) return;
@@ -422,7 +438,11 @@ export const generateTests = (): void => {
   Object.entries(apiGroups).forEach(([groupName, apis]) => {
     const groupHeader = document.createElement("div");
     groupHeader.className = "test-group-header";
-    groupHeader.textContent = groupName;
+    const iconSvg = GROUP_ICONS[groupName] ?? "";
+    groupHeader.innerHTML = `
+      ${iconSvg ? `<span class="test-group-icon">${iconSvg}</span>` : ""}
+      <span class="test-group-title">${escapeHtml(groupName)}</span>
+    `;
     testGrid.appendChild(groupHeader);
 
     apis.forEach((key) => {


### PR DESCRIPTION
 Overview
    Improves visual accessibility, dark mode contrast, typography scaling, and design consistency across the PWAFire console testbench.

   Key Changes
    - Modernize typography scale: replace microscopic base fonts (8px–10px) with accessible sizing (11px–18px) for readability
  across desktop and mobile screens.
    - Enhance dark mode contrast: fix near-black text colors (`#333`/`#444`) on unsupported feature items, secondary buttons, and terminal console logs.
    - Color-code terminal logs: info messages now render in slate blue (`#88a8d0`), errors in alert red (`#ff5555`), and successes in terminal green (`#00ff41`).
    - Align accent color: reset `--color-accent` to the documented `#00ff41` terminal matrix green.
    - Replace raw emojis: swap header emojis (`Docs`, `Playground`) and test category emojis with matching, scalable inline SVG vector icons.
    - Add styling for capability status badges and action buttons.

   Breaking Changes
    - None

